### PR TITLE
fix(ci): use PAT for sync-skills workflow so downstream workflows fire

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # Use a PAT so pushed commits trigger downstream workflows.
+          # GITHUB_TOKEN pushes do not trigger workflow_run / push events.
+          # See: https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs
+          token: ${{ secrets.SYNC_SKILLS_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -31,6 +36,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.SYNC_SKILLS_PAT || secrets.GITHUB_TOKEN }}
           commit-message: 'sync skills from docs.stripe.com/.well-known/skills'
           title: '[automated] sync skills from docs.stripe.com'
           body: |


### PR DESCRIPTION
Closes #355

## What

Switches the `sync-skills` workflow to use a PAT for checkout and the `peter-evans/create-pull-request@v6` step, falling back to `GITHUB_TOKEN` when the secret is not set.

```yaml
token: ${{ secrets.SYNC_SKILLS_PAT || secrets.GITHUB_TOKEN }}
```

## Why

Per [GitHub's docs](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs), events produced by GITHUB_TOKEN pushes / PR creations do NOT trigger new workflow runs (exception: `workflow_dispatch` and `repository_dispatch`). Any workflow configured to run on `push` or `pull_request` is silently skipped when the sync bot creates the PR.

The issue links the GitHub doc directly.

## Activation

To make the fallback route to the real PAT path, create a repo secret:

- **Name:** `SYNC_SKILLS_PAT`
- **Type:** fine-grained PAT scoped to this repository
- **Permissions:** `contents: write`, `pull-requests: write`
- **Expiration:** whatever your org policy prefers

Until the secret is created, the workflow still uses `GITHUB_TOKEN` and keeps working exactly as it does today - this PR does not regress anything.

## Scope

One-line logic change in `.github/workflows/sync-skills.yml`, applied to both the checkout and the create-pull-request steps. No other workflow files touched. No secret added by the PR (that's a maintainer action).

## Verified

- YAML parses cleanly (`ruby -ryaml -e "YAML.load_file(...)"`).
- Fallback syntax is the same pattern used across peter-evans/create-pull-request documentation.

This contribution was developed with AI assistance (Claude Code).
