### PR TITLE
docs: add missing space in examples sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ async def main():
     await toolkit.close()
 ```
 
-Examples for OpenAI's Agent SDK,LangChain, and CrewAI are included in [/examples](/tools/python/examples).
+Examples for OpenAI's Agent SDK, LangChain, and CrewAI are included in [/examples](/tools/python/examples).
 
 ##### Context
 


### PR DESCRIPTION
Fixes a small README formatting typo by adding a missing space after the comma before LangChain.

No code changes.