### PR TITLE
Fix normalized Anthropic max token defaults

### DIFF
--- a/llm/ai-sdk/provider/stripe-language-model-v3.ts
+++ b/llm/ai-sdk/provider/stripe-language-model-v3.ts
@@ -187,13 +187,18 @@ export class StripeLanguageModelV3 implements LanguageModelV3 {
 
     if (
       model.includes('sonnet-4') ||
+      model.includes('claude-3.7-sonnet') ||
       model.includes('claude-3-7-sonnet') ||
+      model.includes('haiku-4.5') ||
       model.includes('haiku-4-5')
     ) {
       return 64000;
     } else if (model.includes('opus-4')) {
       return 32000;
-    } else if (model.includes('claude-3-5-haiku')) {
+    } else if (
+      model.includes('claude-3.5-haiku') ||
+      model.includes('claude-3-5-haiku')
+    ) {
       return 8192;
     } else {
       return 4096;

--- a/llm/ai-sdk/provider/stripe-language-model.ts
+++ b/llm/ai-sdk/provider/stripe-language-model.ts
@@ -208,19 +208,26 @@ export class StripeLanguageModel implements LanguageModelV2 {
     const model = modelId.substring('anthropic/'.length);
 
     // Claude Sonnet 4 models (including variants like sonnet-4-1) and 3.7 Sonnet
-    if (model.includes('sonnet-4') || 
-        model.includes('claude-3-7-sonnet') || 
-        model.includes('haiku-4-5')) {
+    if (
+      model.includes('sonnet-4') ||
+      model.includes('claude-3.7-sonnet') ||
+      model.includes('claude-3-7-sonnet') ||
+      model.includes('haiku-4.5') ||
+      model.includes('haiku-4-5')
+    ) {
       return 64000; // 64K tokens
-    } 
+    }
     // Claude Opus 4 models (including variants like opus-4-1)
     else if (model.includes('opus-4')) {
       return 32000; // 32K tokens
-    } 
+    }
     // Claude 3.5 Haiku
-    else if (model.includes('claude-3-5-haiku')) {
+    else if (
+      model.includes('claude-3.5-haiku') ||
+      model.includes('claude-3-5-haiku')
+    ) {
       return 8192; // 8K tokens
-    } 
+    }
     // Default fallback for other Anthropic models
     else {
       return 4096;

--- a/llm/ai-sdk/provider/tests/stripe-provider-v3.test.ts
+++ b/llm/ai-sdk/provider/tests/stripe-provider-v3.test.ts
@@ -4,6 +4,7 @@
 
 import {createStripeV3, stripeV3} from '../index';
 import {StripeLanguageModelV3} from '../stripe-language-model-v3';
+import type {LanguageModelV3CallOptions} from '@ai-sdk/provider';
 
 describe('Stripe Provider V3', () => {
   describe('createStripeV3', () => {
@@ -276,6 +277,42 @@ describe('Stripe Provider V3', () => {
       it('should normalize opus-4-1 to opus-4.1', () => {
         const model = provider('anthropic/opus-4-1');
         expect(model.modelId).toBe('anthropic/opus-4.1');
+      });
+
+      it('should apply the 64K default to normalized Claude 3.7 Sonnet models', () => {
+        const model = provider('anthropic/claude-3-7-sonnet-20250115');
+        const options: LanguageModelV3CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = model.getArgs(options);
+
+        expect(args.max_tokens).toBe(64000);
+      });
+
+      it('should apply the 8K default to normalized Claude 3.5 Haiku models', () => {
+        const model = provider('anthropic/claude-3-5-haiku-20241022');
+        const options: LanguageModelV3CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = model.getArgs(options);
+
+        expect(args.max_tokens).toBe(8192);
+      });
+
+      it('should apply the 64K default to normalized Haiku 4.5 models', () => {
+        const model = provider('anthropic/claude-haiku-4-5-latest');
+        const options: LanguageModelV3CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = model.getArgs(options);
+
+        expect(args.max_tokens).toBe(64000);
       });
     });
 

--- a/llm/ai-sdk/provider/tests/stripe-provider.test.ts
+++ b/llm/ai-sdk/provider/tests/stripe-provider.test.ts
@@ -4,6 +4,7 @@
 
 import {createStripe, stripe} from '../index';
 import {StripeLanguageModel} from '../stripe-language-model';
+import type {LanguageModelV2CallOptions} from '@ai-sdk/provider';
 
 describe('Stripe Provider', () => {
   describe('createStripe', () => {
@@ -269,6 +270,42 @@ describe('Stripe Provider', () => {
         const model = provider('anthropic/opus-4-1');
         expect(model.modelId).toBe('anthropic/opus-4.1');
       });
+
+      it('should apply the 64K default to normalized Claude 3.7 Sonnet models', () => {
+        const model = provider('anthropic/claude-3-7-sonnet-20250115');
+        const options: LanguageModelV2CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = model.getArgs(options);
+
+        expect(args.max_tokens).toBe(64000);
+      });
+
+      it('should apply the 8K default to normalized Claude 3.5 Haiku models', () => {
+        const model = provider('anthropic/claude-3-5-haiku-20241022');
+        const options: LanguageModelV2CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = model.getArgs(options);
+
+        expect(args.max_tokens).toBe(8192);
+      });
+
+      it('should apply the 64K default to normalized Haiku 4.5 models', () => {
+        const model = provider('anthropic/claude-haiku-4-5-latest');
+        const options: LanguageModelV2CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = model.getArgs(options);
+
+        expect(args.max_tokens).toBe(64000);
+      });
     });
 
     describe('OpenAI models', () => {
@@ -308,4 +345,3 @@ describe('Stripe Provider', () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary

- recognize normalized Anthropic model IDs when applying default `max_tokens`
- cover the regression through the `createStripe()` and `createStripeV3()` provider paths
- keep the fix narrowly scoped to the existing V2 and V3 matchers

## Testing

- `npm test -- --runTestsByPath provider/tests/stripe-provider.test.ts provider/tests/stripe-provider-v3.test.ts provider/tests/stripe-language-model.test.ts provider/tests/stripe-language-model-v3.test.ts`
- `./node_modules/.bin/tsc -p . --noEmit`

Closes #432.
