### PR TITLE
chore(ai-sdk): add npm support metadata

### DIFF
--- a/llm/ai-sdk/package.json
+++ b/llm/ai-sdk/package.json
@@ -2,6 +2,15 @@
   "name": "@stripe/ai-sdk",
   "version": "0.1.3",
   "description": "Stripe AI SDK - Provider and metering utilities for Vercel AI SDK",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stripe/ai.git",
+    "directory": "llm/ai-sdk"
+  },
+  "homepage": "https://github.com/stripe/ai/tree/main/llm/ai-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/stripe/ai/issues"
+  },
   "exports": {
     "./provider": {
       "types": "./dist/provider/index.d.ts",


### PR DESCRIPTION
## Summary

- add npm `repository` metadata for `@stripe/ai-sdk`
- add package homepage metadata pointing at the package docs/source directory
- add `bugs.url` metadata pointing at the Stripe AI issue tracker

## Verification

```sh
node -e "const p=require('./llm/ai-sdk/package.json'); console.log(JSON.stringify({repository:p.repository,homepage:p.homepage,bugs:p.bugs}, null, 2))"
git diff --check
```
