### PR TITLE
Replace .local marker mechanism with hardcoded exemptions for local skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "stripe",
       "source": "./providers/claude/plugin/",
       "description": "Stripe",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Stripe"
       }

--- a/.github/workflows/guard-skills.yml
+++ b/.github/workflows/guard-skills.yml
@@ -6,6 +6,7 @@ on:
       - 'skills/**'
       - '!skills/README.md'
       - 'providers/claude/plugin/skills/**'
+      - '!providers/claude/plugin/skills/connect-recommend/**'
       - 'providers/cursor/plugin/skills/**'
 
 jobs:
@@ -22,45 +23,8 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write
 
-      - name: Check for synced skill changes
-        id: check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-
-            const skillPathPattern = /^(skills|providers\/[^/]+\/plugin\/skills)\/([^/]+)\//;
-            let hasSyncedChanges = false;
-
-            for (const file of files) {
-              const match = file.filename.match(skillPathPattern);
-              if (!match) continue;
-
-              const [, skillsRoot, skillName] = match;
-              try {
-                await github.rest.repos.getContent({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  path: `${skillsRoot}/${skillName}/.local`,
-                  ref: context.payload.pull_request.head.sha,
-                });
-                // .local exists — locally-managed skill, skip
-              } catch {
-                // No .local marker — this is a synced skill change
-                hasSyncedChanges = true;
-                break;
-              }
-            }
-
-            core.setOutput('has_synced_changes', hasSyncedChanges ? 'true' : 'false');
-
       - name: Build review body
         id: message
-        if: steps.check.outputs.has_synced_changes == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -80,7 +44,6 @@ jobs:
             core.setOutput('body', body);
 
       - name: Request changes on PR
-        if: steps.check.outputs.has_synced_changes == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/providers/claude/plugin/.claude-plugin/plugin.json
+++ b/providers/claude/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stripe",
   "description": "Stripe development plugin for Claude",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Stripe",
     "url": "https://stripe.com"

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -26,17 +26,15 @@ const fetchManifest = () => {
 
 const PRESERVE_FILES = new Set(["README.md", ".gitkeep"]);
 const OMIT_FILES = new Set(["metadata.yaml"]);
+// Skills that are locally managed and should not be removed during sync.
+// Add skill directory names here to protect them from being cleaned up.
+const LOCAL_SKILLS = new Set(["connect-recommend"]);
 
 const cleanDirectory = async (dir) => {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
     if (PRESERVE_FILES.has(entry.name)) continue;
-    if (entry.isDirectory()) {
-      try {
-        await fs.access(path.join(dir, entry.name, ".local"));
-        continue; // skip locally-added skill directories
-      } catch {}
-    }
+    if (entry.isDirectory() && LOCAL_SKILLS.has(entry.name)) continue;
     await fs.rm(path.join(dir, entry.name), { recursive: true, force: true });
   }
 };


### PR DESCRIPTION
## Summary

  - Replaces the generic .local file-based exemption in sync.js with an explicit LOCAL_SKILLS set, so protecting a skill from sync cleanup requires a deliberate code change rather than dropping a file
  - Updates guard-skills.yml to use a path exclusion pattern (!providers/claude/plugin/skills/connect-recommend/**) instead of a runtime GitHub API check for .local markers, reverting the workflow to its original simplicity
  - Removes the connect-recommend/.local marker file that was added in the previous PR