### PR TITLE
Connect best practices steering

### DIFF
--- a/skills/stripe-best-practices/SKILL.md
+++ b/skills/stripe-best-practices/SKILL.md
@@ -32,7 +32,7 @@ Before writing any payment or billing code, call the `stripe_implementation_plan
 | One-time payments                                                        | Checkout Sessions                   | <references/payments.md> |
 | Custom payment form with embedded UI                                     | Checkout Sessions + Payment Element | <references/payments.md> |
 | Saving a payment method for later                                        | Setup Intents                       | <references/payments.md> |
-| Connect platform or marketplace                                          | Accounts v2 (`/v2/core/accounts`)   | <references/connect.md> |
+| Connect platform or marketplace                                          | Accounts v2 (`/v2/core/accounts`)   | <references/connect.md>  |
 | Usage-based billing (new integration)                                    | Metronome                           | <references/billing.md>  |
 | Subscriptions or recurring billing                                       | Billing APIs + Checkout Sessions    | <references/billing.md>  |
 | Sales tax, VAT, or GST compliance                                        | Stripe Tax + Registrations API      | <references/tax.md>      |

--- a/skills/stripe-best-practices/SKILL.md
+++ b/skills/stripe-best-practices/SKILL.md
@@ -32,7 +32,7 @@ Before writing any payment or billing code, call the `stripe_implementation_plan
 | One-time payments                                                        | Checkout Sessions                   | <references/payments.md> |
 | Custom payment form with embedded UI                                     | Checkout Sessions + Payment Element | <references/payments.md> |
 | Saving a payment method for later                                        | Setup Intents                       | <references/payments.md> |
-| Connect platform or marketplace                                          | Accounts v2 (`/v2/core/accounts`)   | <references/connect.md>  |
+| Connect platform or marketplace                                          | Accounts v2 (`/v2/core/accounts`)   | <references/connect.md> (charge pattern routing + compatibility checks) |
 | Usage-based billing (new integration)                                    | Metronome                           | <references/billing.md>  |
 | Subscriptions or recurring billing                                       | Billing APIs + Checkout Sessions    | <references/billing.md>  |
 | Sales tax, VAT, or GST compliance                                        | Stripe Tax + Registrations API      | <references/tax.md>      |
@@ -40,6 +40,8 @@ Before writing any payment or billing code, call the `stripe_implementation_plan
 | Security (key management, RAKs, webhooks, OAuth, 2FA, Connect liability) | See security reference              | <references/security.md> |
 
 Read the relevant reference file before answering any integration question or writing code.
+
+For Connect recommendations, always validate the final `(dashboard, fees_collector, losses_collector, charge pattern)` combination against `references/connect.md` before giving implementation guidance.
 
 ## Critical rules
 

--- a/skills/stripe-best-practices/SKILL.md
+++ b/skills/stripe-best-practices/SKILL.md
@@ -32,7 +32,7 @@ Before writing any payment or billing code, call the `stripe_implementation_plan
 | One-time payments                                                        | Checkout Sessions                   | <references/payments.md> |
 | Custom payment form with embedded UI                                     | Checkout Sessions + Payment Element | <references/payments.md> |
 | Saving a payment method for later                                        | Setup Intents                       | <references/payments.md> |
-| Connect platform or marketplace                                          | Accounts v2 (`/v2/core/accounts`)   | <references/connect.md> (charge pattern routing + compatibility checks) |
+| Connect platform or marketplace                                          | Accounts v2 (`/v2/core/accounts`)   | <references/connect.md> |
 | Usage-based billing (new integration)                                    | Metronome                           | <references/billing.md>  |
 | Subscriptions or recurring billing                                       | Billing APIs + Checkout Sessions    | <references/billing.md>  |
 | Sales tax, VAT, or GST compliance                                        | Stripe Tax + Registrations API      | <references/tax.md>      |

--- a/skills/stripe-best-practices/references/connect.md
+++ b/skills/stripe-best-practices/references/connect.md
@@ -103,7 +103,7 @@ Blocked combinations to never recommend:
 Caution combinations:
 
 - `express` + `application` + `application` with destination charges or separate charges and transfers requires platform-run webhook recovery for refunds/disputes and transfer reversals.
-- Express dashboards have limited self-service payment-management controls for these charge types; the platform must own operational workflows.
+- Express dashboards have limited self-service payment-management controls for destination charges and separate charges and transfers; the platform must own operational workflows.
 
 Blessed paths:
 

--- a/skills/stripe-best-practices/references/connect.md
+++ b/skills/stripe-best-practices/references/connect.md
@@ -3,46 +3,219 @@
 ## Table of contents
 
 - Accounts v2 API
-- Controller properties
-- Charge types
+- Account configuration dimensions
+- Business model to configuration mapping
+- Charge pattern selection
+- Compatibility matrix
+- Fee economics
+- Connected account configuration
+- Onboarding guidance
+- Traps to avoid
 - Integration guides
 
 ## Accounts v2 API
 
-For new Connect platforms, ALWAYS use the [Accounts v2 API](https://docs.stripe.com/connect/accounts-v2.md) (`POST /v2/core/accounts`). This is Stripe’s actively invested path and ensures long-term support.
+For new Connect platforms, ALWAYS use the [Accounts v2 API](https://docs.stripe.com/connect/accounts-v2.md) (`POST /v2/core/accounts`). This is Stripe's actively invested path and ensures long-term support.
 
-**Traps to avoid:** Don’t use the legacy `type` parameter (`type: 'express'`, `type: 'custom'`, `type: 'standard'`) in `POST /v1/accounts` for new platforms unless the user has explicitly requested v1.
+Describe recommendations using explicit field values instead of legacy account-type labels:
 
-## Controller properties
+- `dashboard` (`express`, `full`, `none`)
+- `defaults.responsibilities.fees_collector` (`stripe`, `application`)
+- `defaults.responsibilities.losses_collector` (`stripe`, `application`)
+- charge pattern (`direct`, `destination`, `separate charges and transfers`)
 
-Configure connected accounts using `controller` properties instead of legacy account types:
+**Traps to avoid:**
 
-| Property                            | Controls                                     |
-| ----------------------------------- | -------------------------------------------- |
-| `controller.losses.payments`        | Who is liable for negative balances          |
-| `controller.fees.payer`             | Who pays Stripe fees                         |
-| `controller.stripe_dashboard.type`  | Dashboard access (`full`, `express`, `none`) |
-| `controller.requirement_collection` | Who collects onboarding requirements         |
+- Do not recommend `type: 'standard' | 'express' | 'custom'` in `POST /v1/accounts` for new integrations unless the user explicitly requests v1.
+- Do not describe new integrations only with legacy labels ("Standard", "Express", "Custom"). Use v2 field values.
 
-Use `defaults.responsibilities`, `dashboard`, and `configuration` as described in [connected account configuration](https://docs.stripe.com/connect/accounts-v2/connected-account-configuration.md).
+## Account configuration dimensions
 
-Always describe accounts in terms of their responsibility settings, dashboard access, and [capabilities](https://docs.stripe.com/connect/account-capabilities.md) to describe what connected accounts can do.
+In Accounts v2, configure three independent dimensions:
 
-**Traps to avoid:** Don’t use the terms “Standard”, “Express”, or “Custom” as account types. These are legacy categories that bundle together responsibility, dashboard, and requirement decisions into opaque labels. Controller properties give explicit control over each dimension.
+| Dimension | Field | What it controls |
+| --- | --- | --- |
+| Dashboard access | `dashboard` | Whether connected accounts get Stripe-hosted dashboard access |
+| Fee collection | `defaults.responsibilities.fees_collector` | Who Stripe bills for fees (`stripe` or `application`) |
+| Negative balance liability | `defaults.responsibilities.losses_collector` | Who absorbs unresolved negative balances (`stripe` or `application`) |
 
-## Charge types
+Default direction by business shape:
 
-Choose one charge type per integration — don’t mix them. For most platforms, start with destination charges:
+- Marketplace-style flow (platform runs checkout): `dashboard: "express"`, `fees_collector: "application"`, `losses_collector: "application"`
+- SaaS-style flow (seller runs checkout): `dashboard: "full"`, `fees_collector: "stripe"`, `losses_collector: "stripe"`
+- White-label / enterprise control: `dashboard: "none"`, `fees_collector: "application"`, `losses_collector: "application"`
 
-- **Destination charges** — Use when the platform accepts liability for negative balances. Funds route to the connected account via `transfer_data.destination`.
-- **Direct charges** — Use when the platform wants Stripe to take risk on the connected account. The charge is created on the connected account directly.
+## Business model to configuration mapping
 
-Use `on_behalf_of` to control the merchant of record, but only after reading [how charges work in Connect](https://docs.stripe.com/connect/charges.md).
+Use this as the primary routing table when a user asks for Connect setup guidance:
 
-**Traps to avoid:** Don’t use the Charges API for Connect fund flows — use PaymentIntents or Checkout Sessions with `transfer_data` or `on_behalf_of`. Don’t mix charge types within a single integration.
+| Business model | Dashboard | Fees | Losses | Charge pattern | Why |
+| --- | --- | --- | --- | --- | --- |
+| Marketplace | `express` | `application` | `application` | Destination | Platform owns checkout and payment operations |
+| On-demand services | `express` | `application` | `application` | Destination | Fast seller onboarding, platform-operated checkout |
+| Professional services marketplace | `express` | `application` | `application` | Destination | Similar to marketplace flow |
+| SaaS platform with payments | `full` | `stripe` | `stripe` | Direct | Sellers are independent merchants of record |
+| Crowdfunding | `express` | `application` | `application` | Separate charges and transfers | Flexible split and delayed release flows |
+| Subscription platform (platform-run checkout) | `express` | `application` | `application` | Destination | Platform manages recurring checkout flow |
+| White-label commerce | `none` | `application` | `application` | Destination or direct | Platform controls UX and operations |
+| B2B platform with multi-party allocation | `none` | `application` | `application` | Separate charges and transfers | Complex split and approval workflows |
+
+## Charge pattern selection
+
+Use one charge pattern per primary flow. Only use hybrid patterns when there is a clear need and the user accepts additional operational complexity.
+
+```
+How many sellers per transaction?
+|- Multiple sellers -> Separate charges and transfers
+`- One seller
+   |- Seller runs checkout and is merchant of record -> Direct charges
+   `- Platform runs checkout and is merchant of record -> Destination charges
+```
+
+Detailed rules:
+
+- Choose **destination charges** for the common marketplace flow where the platform owns checkout, customer support, and payment operations.
+- Choose **direct charges** when each connected account independently owns the payment relationship and should appear on statements.
+- Choose **separate charges and transfers** for hold-and-release timing, delivery-gated payouts, or one payment split across multiple connected accounts.
+- Do not describe destination charges as hold-and-release behavior; destination transfers happen automatically when payment succeeds.
+- `on_behalf_of` is out of scope for this guide. If required, direct users to [Connect charges docs](https://docs.stripe.com/connect/charges.md) or [Stripe sales](https://stripe.com/contact/sales).
+
+## Compatibility matrix
+
+Validate `(dashboard, fees_collector, losses_collector)` against charge pattern before finalizing a recommendation:
+
+| Dashboard | Fees collector | Losses collector | Direct | Destination | Separate charges and transfers |
+| --- | --- | --- | --- | --- | --- |
+| `full` | `stripe` | `stripe` | ALLOWED | BLOCKED | BLOCKED |
+| `express` | `application` | `application` | ALLOWED | CAUTION | CAUTION |
+| `express` | `stripe` | `stripe` | BLOCKED | BLOCKED | BLOCKED |
+| `express` | `application` | `stripe` | BLOCKED | BLOCKED | BLOCKED |
+| `none` | `stripe` | `stripe` | ALLOWED | BLOCKED | BLOCKED |
+| `none` | `application` | `stripe` | ALLOWED | BLOCKED | BLOCKED |
+| `none` | `application` | `application` | ALLOWED | ALLOWED | ALLOWED |
+
+Blocked combinations to never recommend:
+
+- `losses_collector: "stripe"` with destination charges or separate charges and transfers
+- Express configurations where losses are Stripe-owned (`losses_collector: "stripe"`)
+- `application_fee_amount` with separate charges and transfers
+
+Caution combinations:
+
+- `express` + `application` + `application` with destination charges or separate charges and transfers requires platform-run webhook recovery for refunds/disputes and transfer reversals.
+- Express dashboards have limited self-service payment-management controls for these charge types; the platform must own operational workflows.
+
+Blessed paths:
+
+| Business shape | Dashboard | Fees | Losses | Charge pattern |
+| --- | --- | --- | --- | --- |
+| Marketplace | `express` | `application` | `application` | Destination |
+| SaaS platform | `full` | `stripe` | `stripe` | Direct |
+| Enterprise / white-label | `none` | `application` | `application` | Direct, destination, or separate |
+
+## Fee economics
+
+Who pays Stripe processing fees depends on charge pattern and responsibilities:
+
+| Pattern | Who pays Stripe processing fees | Platform net framing |
+| --- | --- | --- |
+| Direct charges + `fees_collector: "stripe"` | Connected account | Platform usually keeps full `application_fee_amount` |
+| Direct charges + `fees_collector: "application"` | Platform | `application_fee_amount - Stripe_fees` |
+| Destination charges | Platform | `application_fee_amount - Stripe_fees` |
+| Separate charges and transfers | Platform | `charge_amount - total_transfers - Stripe_fees` |
+
+Guidance:
+
+- For destination charges and separate charges and transfers, do not say "seller pays Stripe fees." Platform economics must account for Stripe fees.
+- If margin is low or uncertain, recommend fee logic that preserves margin (for destination flows, include Stripe fee estimates in fee calculation).
+- Never use `application_fee_amount` for separate charges and transfers; use transfer-math fee retention.
+- Recommend [Platform Pricing Tool](https://dashboard.stripe.com/settings/connect/platform_pricing) when platform-owned pricing is required.
+- Advise users to check current region-specific rates at [stripe.com/pricing](https://stripe.com/pricing) and monitor margin reporting.
+
+## Connected account configuration
+
+Match account configuration to charge pattern.
+
+Marketplace-style accounts (destination or separate charges and transfers):
+
+```javascript
+const account = await stripe.v2.core.accounts.create({
+  dashboard: 'express',
+  identity: { country: 'us', entity_type: 'individual' },
+  configuration: {
+    recipient: {
+      capabilities: {
+        stripe_balance: { stripe_transfers: { requested: true } },
+      },
+    },
+  },
+  defaults: {
+    responsibilities: {
+      fees_collector: 'application',
+      losses_collector: 'application',
+    },
+  },
+});
+```
+
+SaaS-style accounts (direct charges):
+
+```javascript
+const account = await stripe.v2.core.accounts.create({
+  dashboard: 'full',
+  identity: { country: 'us', entity_type: 'individual' },
+  configuration: {
+    merchant: {
+      capabilities: {
+        card_payments: { requested: true },
+      },
+    },
+  },
+  defaults: {
+    responsibilities: {
+      fees_collector: 'stripe',
+      losses_collector: 'stripe',
+    },
+  },
+});
+```
+
+Readiness checks before processing payments/transfers:
+
+- Marketplace flow: verify `configuration.recipient.capabilities.stripe_balance.stripe_transfers.status === 'active'` before transferring funds.
+- SaaS flow: verify `configuration.merchant.capabilities.card_payments.status === 'active'` before creating direct charges.
+
+## Onboarding guidance
+
+Default to [embedded onboarding](https://docs.stripe.com/connect/embedded-onboarding.md). It reduces compliance burden and keeps users in-app.
+
+Alternative paths:
+
+- Stripe-hosted onboarding is acceptable when embedded UX is not required.
+- API-based custom onboarding should be recommended only for advanced teams with dedicated compliance resources.
+
+If users choose `dashboard: "none"` without embedded components, warn that they must build and maintain:
+
+- onboarding and ongoing requirement remediation
+- refund and dispute workflows
+- payout and earnings management surfaces
+
+## Traps to avoid
+
+- Recommending legacy account types (`standard`, `express`, `custom`) for new integrations
+- Recommending Charges API for Connect fund flows instead of PaymentIntents/Checkout
+- Using `losses_collector: "stripe"` with destination charges or separate charges and transfers
+- Recommending destination charges for hold-and-release payout requirements
+- Using `application_fee_amount` with separate charges and transfers
+- Ignoring dispute transfer-reversal logic for destination/separate flows
+- Recommending OAuth account-connection patterns as the default self-serve onboarding path
+- Recommending `on_behalf_of` for standard marketplace flows
+- Recommending `dashboard: "none"` without warning about full operational scope
 
 ## Integration guides
 
-- [SaaS platforms and marketplaces guide](https://docs.stripe.com/connect/saas-platforms-and-marketplaces.md) — Choosing the right integration shape.
-- [Interactive platform guide](https://docs.stripe.com/connect/interactive-platform-guide.md) — Step-by-step platform builder.
-- [Design an integration](https://docs.stripe.com/connect/design-an-integration.md) — Detailed risk and responsibility decisions.
+- [SaaS platforms and marketplaces guide](https://docs.stripe.com/connect/saas-platforms-and-marketplaces.md)
+- [Interactive platform guide](https://docs.stripe.com/connect/interactive-platform-guide.md)
+- [Design an integration](https://docs.stripe.com/connect/design-an-integration.md)
+- [How charges work in Connect](https://docs.stripe.com/connect/charges.md)
+- [Connected account configuration (v2)](https://docs.stripe.com/connect/accounts-v2/connected-account-configuration.md)


### PR DESCRIPTION
## Summary

This PR translates the Connect steering logic from the `connect-recommend` work into `stripe-best-practices` so Connect recommendations are more consistent and more robust in eval scenarios.

## What changed

- Rewrote `skills/stripe-best-practices/references/connect.md` to include:
  - Accounts v2 field-based guidance (instead of legacy account-type framing)
  - Business model to configuration mapping
  - Charge pattern decision tree (direct vs destination vs separate charges and transfers)
  - Compatibility matrix with blocked/caution combinations
  - Fee economics guidance by charge pattern
  - Connected account configuration examples (`configuration.recipient` vs `configuration.merchant`)
  - Onboarding guidance and a consolidated traps section
- Updated `skills/stripe-best-practices/SKILL.md` to strengthen Connect routing:
  - Routing table now explicitly calls out charge pattern routing + compatibility checks
  - Added a rule to validate `(dashboard, fees_collector, losses_collector, charge pattern)` against `references/connect.md` before implementation guidance

## Intent and scope

- Ports the decision-driving Connect content from the steering work into a non-interactive reference format appropriate for `stripe-best-practices`.
- Intentionally does **not** port interactive/agent workflow mechanics (question flows, subagents, plugin-specific config handling).

## Validation

- Confirmed only intended files changed:
  - `skills/stripe-best-practices/references/connect.md`
  - `skills/stripe-best-practices/SKILL.md`
- Searched for internal/plugin-only references in updated skill files and found none.
- No runtime code changes; docs/skill-content update only.

## Test plan

- [x] Manual diff review for content correctness and scope
- [x] Internal-reference leak check on updated files
- [ ] Run structured eval slice for Connect scenarios to measure pass-rate impact