### PR TITLE
Bump plugin versions automatically on skill sync

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -45,7 +45,7 @@ jobs:
           !github.event.repository.fork
         shell: bash
         run: |
-          git add ':(glob)**/skills/**'
+          git add ':(glob)**/skills/**' .claude-plugin/marketplace.json providers/claude/plugin/.claude-plugin/plugin.json .cursor-plugin/marketplace.json providers/cursor/plugin/.cursor-plugin/plugin.json
 
           # Skip if nothing changed
           if git diff --staged --quiet; then

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -39,12 +39,62 @@ const cleanDirectory = async (dir) => {
   }
 };
 
+const REPO_ROOT = path.join(__dirname, "..");
+
 const SKILLS_DIR = path.join(__dirname, "../skills");
 const PLUGIN_SKILLS_DIRS = [
   path.join(__dirname, "../providers/claude/plugin/skills"),
   path.join(__dirname, "../providers/cursor/plugin/skills"),
 ];
 const ALL_OUTPUT_DIRS = [SKILLS_DIR, ...PLUGIN_SKILLS_DIRS];
+
+const VERSION_FILES = [
+  path.join(__dirname, "../.claude-plugin/marketplace.json"),
+  path.join(__dirname, "../providers/claude/plugin/.claude-plugin/plugin.json"),
+  path.join(__dirname, "../.cursor-plugin/marketplace.json"),
+  path.join(__dirname, "../providers/cursor/plugin/.cursor-plugin/plugin.json"),
+];
+
+const bumpVersion = (version, type) => {
+  const [major, minor, patch] = version.split(".").map(Number);
+  if (type === "minor") return `${major}.${minor + 1}.0`;
+  return `${major}.${minor}.${patch + 1}`;
+};
+
+const updateVersionFile = async (filePath, bumpType) => {
+  const raw = await fs.readFile(filePath, "utf8");
+  const content = JSON.parse(raw);
+  if (content.version) {
+    content.version = bumpVersion(content.version, bumpType);
+  }
+  if (content.plugins) {
+    for (const plugin of content.plugins) {
+      if (plugin.version) plugin.version = bumpVersion(plugin.version, bumpType);
+    }
+  }
+  await fs.writeFile(filePath, JSON.stringify(content, null, 2) + "\n", "utf8");
+  console.log(`  Bumped version in: ${path.relative(REPO_ROOT, filePath)}`);
+};
+
+// Returns { added, deleted, modified } by inspecting git working-tree status
+// for the canonical skills directory after files have been written.
+const getGitSkillChanges = () => {
+  const skillsRel = path.relative(REPO_ROOT, SKILLS_DIR);
+  try {
+    const output = execSync(`git status --porcelain -- "${skillsRel}"`, {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    });
+    const lines = output.trim().split("\n").filter(Boolean);
+    // porcelain format: "XY path" where X=index, Y=worktree; "??" = untracked
+    const added = lines.some((l) => l.startsWith("??"));
+    const deleted = lines.some((l) => l[1] === "D");
+    const modified = lines.some((l) => !l.startsWith("??") && l[1] !== "D");
+    return { added, deleted, modified };
+  } catch {
+    return { added: false, deleted: false, modified: false };
+  }
+};
 
 const run = async () => {
   const manifest = fetchManifest();
@@ -83,6 +133,17 @@ const run = async () => {
 
   if (errors > 0) {
     throw new Error(`Sync completed with ${errors} error(s)`);
+  }
+
+  const { added, deleted, modified } = getGitSkillChanges();
+  if (added || deleted || modified) {
+    const bumpType = added || deleted ? "minor" : "patch";
+    console.log(`Skills changed (type: ${bumpType}), bumping plugin versions`);
+    for (const versionFile of VERSION_FILES) {
+      await updateVersionFile(versionFile, bumpType);
+    }
+  } else {
+    console.log("No skill changes detected, skipping version bump");
   }
 };
 


### PR DESCRIPTION
## Summary

Plugin consumers (Claude, Cursor) cache plugins by version and won't pick up updated skill content unless the version changes. Previously, the daily sync wrote new skill files but never bumped versions, so updates were silently ignored by anyone who had already installed the plugin.

## Changes
  
After writing skill files, `sync.js` now uses `git status --porcelain` to detect what actually changed, then bumps all four plugin version manifests accordingly:

  - **Patch bump** (`0.2.0 → 0.2.1`): existing skill files were updated
  - **Minor bump** (`0.2.0 → 0.3.0`): a skill was added or removed

  The four version files updated on each bump:
  - `.claude-plugin/marketplace.json`
  - `providers/claude/plugin/.claude-plugin/plugin.json`
  - `.cursor-plugin/marketplace.json`
  - `providers/cursor/plugin/.cursor-plugin/plugin.json`

The sync workflow's `git add` is extended to stage these files alongside the skill content, so they land in the same `sync skills` commit. The existing "skip if nothing changed" guard ensures no commit (and no version bump) happens when upstream skills are identical to what's already in the repo.

## Testing

Tested manually locally by modifying the git history:

Test patch bump — commit a stale version of a skill file so HEAD differs from upstream:
```
# Pick any skill file and make HEAD look "old"
SKILL_FILE="skills/stripe-best-practices/skill.md"
echo "old content" > $SKILL_FILE
git add $SKILL_FILE && git commit -m "test: simulate stale skill"

# Run the sync — it'll write the real upstream content, git sees it as modified
node scripts/sync.js
# Expect: "Skills changed (type: patch), bumping plugin versions"
```

Test minor bump (add) — same idea but delete a skill dir from HEAD:

```
git rm -r skills/stripe-best-practices
git commit -m "test: simulate missing skill"

node scripts/sync.js
# Expect: "Skills changed (type: minor), bumping plugin versions"
```

Test minor bump (delete) — commit a fake skill that doesn't exist upstream:

```
mkdir -p skills/fake-skill && echo "fake" > skills/fake-skill/skill.md
git add skills/fake-skill && git commit -m "test: simulate extra skill"

node scripts/sync.js
# cleanDirectory removes fake-skill, git sees it as deleted → minor bump
```