### PR TITLE
Add Grok Build provider plugin

### DIFF
--- a/.github/workflows/guard-skills.yml
+++ b/.github/workflows/guard-skills.yml
@@ -11,6 +11,8 @@ on:
       - '!providers/codex/plugin/skills/connect-recommend/**'
       - 'providers/cursor/plugin/skills/**'
       - '!providers/cursor/plugin/skills/connect-recommend/**'
+      - 'providers/grok/plugin/skills/**'
+      - '!providers/grok/plugin/skills/connect-recommend/**'
 
 jobs:
   block:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -49,9 +49,11 @@ jobs:
             ':(glob)**/skills/**' \
             .claude-plugin/marketplace.json \
             .cursor-plugin/marketplace.json \
+            .grok-plugin/marketplace.json \
             providers/claude/plugin/.claude-plugin/plugin.json \
             providers/codex/plugin/.codex-plugin/plugin.json \
-            providers/cursor/plugin/.cursor-plugin/plugin.json
+            providers/cursor/plugin/.cursor-plugin/plugin.json \
+            providers/grok/plugin/.grok-plugin/plugin.json
 
           # Skip if nothing changed
           if git diff --staged --quiet; then

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "stripe",
       "source": "./providers/grok/plugin/",
       "description": "Stripe",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Stripe"
       }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "stripe",
+  "owner": {
+    "name": "Stripe",
+    "email": "support@stripe.com"
+  },
+  "plugins": [
+    {
+      "name": "stripe",
+      "source": "./providers/grok/plugin/",
+      "description": "Stripe",
+      "version": "0.1.0",
+      "author": {
+        "name": "Stripe"
+      }
+    }
+  ]
+}

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "stripe",
       "source": "./providers/grok/plugin/",
       "description": "Stripe",
-      "version": "0.1.2",
+      "version": "0.1.0",
       "author": {
         "name": "Stripe"
       }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "stripe",
       "source": "./providers/grok/plugin/",
       "description": "Stripe",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": {
         "name": "Stripe"
       }

--- a/README.md
+++ b/README.md
@@ -49,21 +49,11 @@ You can also install through the [Cursor marketplace](https://cursor.com/marketp
 
 ### Grok Build
 
-Point a marketplace source at this repo and install the `stripe` plugin from `providers/grok/plugin` (SHA-pinned). Example catalog entry:
+Run this command in your project:
 
-```json
-{
-  "name": "stripe",
-  "source": {
-    "source": "url",
-    "url": "https://github.com/stripe/ai.git",
-    "sha": "<commit sha>",
-    "path": "providers/grok/plugin"
-  }
-}
+```bash
+grok plugin install stripe --trust
 ```
-
-Or for local testing, add a path plugin source to `~/.grok/config.toml` pointing at `providers/grok/plugin` in a checkout of this repo.
 
 ## Manual installation
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ Run this command in your project:
 
 You can also install through the [Cursor marketplace](https://cursor.com/marketplace/stripe).
 
+### Grok Build
+
+Point a marketplace source at this repo and install the `stripe` plugin from `providers/grok/plugin` (SHA-pinned). Example catalog entry:
+
+```json
+{
+  "name": "stripe",
+  "source": {
+    "source": "url",
+    "url": "https://github.com/stripe/ai.git",
+    "sha": "<commit sha>",
+    "path": "providers/grok/plugin"
+  }
+}
+```
+
+Or for local testing, add a path plugin source to `~/.grok/config.toml` pointing at `providers/grok/plugin` in a checkout of this repo.
+
 ## Manual installation
 
 > Manually installed skills don’t auto-update. Run `npx skills update -y` to get the latest versions.

--- a/providers/README.md
+++ b/providers/README.md
@@ -9,3 +9,8 @@ This directory contains plugins for different AI code editors.
 Skills in `providers/*/plugin/skills/` are automatically synced from [docs.stripe.com/.well-known/skills](https://docs.stripe.com/.well-known/skills) via the [sync-skills workflow](/.github/workflows/sync-skills.yml). Any manual changes will be overwritten.
 
 To manually trigger a sync, go to the [workflow page](https://github.com/stripe/agent-toolkit/actions/workflows/sync-skills.yml) and click "Run workflow".
+
+## Local-only skills
+
+`connect-recommend` is maintained per provider (not overwritten by the docs.stripe.com sync). Provider-specific wiring (subagent spawn, tool names, path tokens) lives there. Do not move Connect recommendation logic into the synced skill set without updating `LOCAL_SKILLS` in `scripts/sync.js`.
+

--- a/providers/grok/plugin/.grok-plugin/plugin.json
+++ b/providers/grok/plugin/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe",
-  "description": "Stripe development plugin for Grok Build: best-practice skills, Connect recommendation, and the hosted Stripe MCP server.",
+  "description": "Stripe development plugin for Grok Build: best practices, API/SDK upgrade guidance, and the Stripe MCP server.",
   "version": "0.1.0",
   "author": {
     "name": "Stripe",

--- a/providers/grok/plugin/.grok-plugin/plugin.json
+++ b/providers/grok/plugin/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stripe",
   "description": "Stripe development plugin for Grok Build: best-practice skills, Connect recommendation, and the hosted Stripe MCP server.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Stripe",
     "url": "https://stripe.com"

--- a/providers/grok/plugin/.grok-plugin/plugin.json
+++ b/providers/grok/plugin/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stripe",
   "description": "Stripe development plugin for Grok Build: best-practice skills, Connect recommendation, and the hosted Stripe MCP server.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Stripe",
     "url": "https://stripe.com"

--- a/providers/grok/plugin/.grok-plugin/plugin.json
+++ b/providers/grok/plugin/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stripe",
   "description": "Stripe development plugin for Grok Build: best-practice skills, Connect recommendation, and the hosted Stripe MCP server.",
-  "version": "0.1.2",
+  "version": "0.1.0",
   "author": {
     "name": "Stripe",
     "url": "https://stripe.com"

--- a/providers/grok/plugin/.grok-plugin/plugin.json
+++ b/providers/grok/plugin/.grok-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "stripe",
+  "description": "Stripe development plugin for Grok Build: best-practice skills, Connect recommendation, and the hosted Stripe MCP server.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Stripe",
+    "url": "https://stripe.com"
+  },
+  "homepage": "https://docs.stripe.com",
+  "repository": "https://github.com/stripe/ai",
+  "license": "MIT",
+  "keywords": [
+    "stripe",
+    "payments",
+    "webhooks",
+    "api",
+    "security",
+    "grok",
+    "grok build"
+  ]
+}

--- a/providers/grok/plugin/.mcp.json
+++ b/providers/grok/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "stripe": {
+      "type": "http",
+      "url": "https://mcp.stripe.com"
+    }
+  }
+}

--- a/providers/grok/plugin/agents/company-researcher.md
+++ b/providers/grok/plugin/agents/company-researcher.md
@@ -1,5 +1,5 @@
 ---
-name: Company Researcher
+name: company-researcher
 description: "Research a company from its URL or description to infer Stripe Connect integration shape"
 tools:
   - Read

--- a/providers/grok/plugin/agents/company-researcher.md
+++ b/providers/grok/plugin/agents/company-researcher.md
@@ -1,0 +1,118 @@
+---
+name: Company Researcher
+description: "Research a company from its URL or description to infer Stripe Connect integration shape"
+tools:
+  - Read
+  - Glob
+  - Grep
+  - WebFetch
+  - WebSearch
+---
+
+# Company Researcher Agent
+
+Research a company using its website URL or a text description, then map findings to the Stripe Connect decision matrix. Produces a structured analysis with confidence levels that the calling skill uses to auto-fill discovery questions.
+
+You only have research tools (read/search/list/web). On Grok Build these appear as `read_file`, `grep`, `list_dir`, `web_fetch`, and `web_search` (Claude names in the frontmatter map to those). Do not attempt to write files or run shell commands.
+
+## Inputs
+
+You will receive one or both of:
+- **Company URL** — a website to fetch and analyze
+- **Company description** — freeform text about what the business does
+
+## Instructions
+
+### Step 1 — Gather company information from the web
+
+**If a URL is provided:**
+
+1. `WebFetch` the homepage. Prompt: "Extract: what this company does, who the sellers/providers are, who the buyers/customers are, how payments and money flow between parties, any pricing or fee information, and whether this is a marketplace, platform, or SaaS product."
+
+2. Attempt to fetch deeper pages for additional signals. Try these URL suffixes in parallel and use whatever succeeds:
+   - `/about`, `/about-us`, `/how-it-works` — for business model clarity
+   - `/pricing`, `/plans` — for fee structure
+
+3. If the homepage fetch fails (403, 404, timeout, empty content), fall back to `WebSearch` using the domain name plus "business model how it works".
+
+**If only a description is provided (no URL):**
+
+1. `WebSearch` for the company name (if identifiable) plus "business model" and "pricing".
+2. If the description is generic (e.g. "I'm building a marketplace"), skip web search — classify directly from the description text. Maximum confidence for description-only inferences is MEDIUM.
+
+**If both `WebFetch` and `WebSearch` are unavailable or fail:**
+
+If no description text is available (URL-only input and web research failed), return the early-exit output from Step 4 with all dimensions set to LOW confidence and the note: "Web research unavailable and no description provided. Cannot perform research."
+
+Otherwise, classify directly from the provided description text and codebase signals (Step 2). Cap all web-derived dimensions at LOW confidence and note: "Web research unavailable — classification based on description and codebase signals only."
+
+**If neither URL nor description is provided:**
+
+Return the early-exit output (see Step 4 failure format) with all dimensions set to LOW confidence and the note: "No company URL or description provided. Cannot perform research."
+
+### Step 2 — Cross-reference with codebase signals (if a project exists)
+
+Check if there's an existing project to scan:
+
+1. `Glob` for `package.json`, `requirements.txt`, `Gemfile`, `go.mod`, `pom.xml` at the project root.
+
+2. If a project exists, `Grep` for business model signals:
+   - Seller/provider patterns: `seller`, `vendor`, `operator`, `provider`, `merchant`, `host`, `creator`
+   - Buyer patterns: `buyer`, `customer`, `rider`, `guest`, `client`
+   - Payment patterns: `commission`, `fee`, `split`, `payout`, `transfer`, `earnings`
+   - Multi-party patterns: `marketplace`, `platform`, `connect`
+
+3. Check if `connect-recommend-plan.md` already exists. If it does, ask if the user wants to start over and generate a fresh recommendation.
+
+4. Use codebase signals to corroborate or strengthen web research findings. For example, if the homepage says "marketplace" and the codebase has terms like `commission`, `payout`, `split`, `listing`, `booking`, `cart`, `order`, `storefront`, or `seller`/`vendor`/`provider` patterns, that's stronger confirmation.
+
+### Step 3 — Assess confidence per dimension
+
+For each of the 6 dimensions below, report what you found and how confident you are. Do NOT interpret the decision matrix or derive a recommended configuration — that happens downstream.
+
+| Dimension | What to determine | Confidence: HIGH | Confidence: MEDIUM | Confidence: LOW |
+|-----------|-------------------|------------------|--------------------|-----------------|
+| **Business model** | marketplace, on-demand services, professional services, SaaS with payments, crowdfunding, subscription platform, rental marketplace, event ticketing, e-commerce (white-label), B2B platform | Explicit on homepage or about page | Inferred from product description or competitor comparison | Guessing from vague signals |
+| **Parties** | Who are the sellers/providers? Who are the buyers? | Roles explicitly named on the site | Inferred from business model type | No party information found |
+| **Payment flow** | Platform collects → pays out? Buyers pay sellers directly? Platform processes on behalf? | Pricing page or docs describe the flow | Inferred from business model (e.g. marketplaces usually collect) | No payment information found |
+| **Onboarding control** | Embedded, Stripe-hosted redirect, or fully custom/API | Custom onboarding shown on site, or white-label signals | Default inference from business model | Contradictory signals |
+| **Dispute responsibility** | Platform handles, sellers handle, or shared | Explicitly stated in terms/policies | Inferred from model (marketplace → platform usually) | No information |
+| **Fee structure** | Percentage, flat, tiered, subscription+tx | Pricing page shows exact fee structure | Inferred from competitor patterns or partial info | No pricing information found |
+
+### Step 4 — Produce structured output
+
+Write the Summary section as if speaking directly to the user, using second person. Say "Your barbers are..." not "The barbers are...". Frame findings as a conversational confirmation seeking validation.
+
+Return your analysis in this exact format:
+
+```
+## Company Research: [Company Name or "Unknown"]
+
+### Summary
+[2-3 sentences speaking directly to the user: what their company does, their key parties, and how money flows. Use "you/your" — e.g., "Your platform connects customers with barbers who provide services. You collect payment from customers and pay out barbers after taking a platform fee."]
+
+### Research Findings
+
+| Dimension      | Finding                                  | Confidence       | Evidence                 |
+|----------------|------------------------------------------|------------------|--------------------------|
+| Business Model | [type from the dimension table above]    | [HIGH/MEDIUM/LOW] | [1-sentence explanation] |
+| Parties        | [sellers] (sellers) + [buyers] (buyers)  | [HIGH/MEDIUM/LOW] | [1-sentence explanation] |
+| Payment Flow   | [observed flow description]              | [HIGH/MEDIUM/LOW] | [1-sentence explanation] |
+| Onboarding     | [signals about onboarding preferences]   | [HIGH/MEDIUM/LOW] | [1-sentence explanation] |
+| Disputes       | [who appears to handle]                  | [HIGH/MEDIUM/LOW] | [1-sentence explanation] |
+| Fee Structure  | [type]: [details]                        | [HIGH/MEDIUM/LOW] | [1-sentence explanation] |
+
+### Sources
+- [list each URL fetched or search query used]
+```
+
+### Step 5 — Handle edge cases
+
+| Scenario | What to do |
+|----------|------------|
+| **URL returns 403/404/timeout** | Fall back to `WebSearch` with the domain name. Note in Sources: "Direct URL unreachable, used web search." |
+| **URL is a SPA with minimal HTML** | `WebFetch` may return little content. Fall back to `WebSearch`. Check meta tags and page title. |
+| **Pricing is behind a login** | Fee structure confidence drops to LOW. Note: "Pricing not publicly available." |
+| **Company does multiple things** | Note the ambiguity. Classify based on the primary product. Set confidence to MEDIUM with reasoning about which facet you chose. |
+| **Not a marketplace or platform** | If the business is purely B2C with no multi-party payments, flag clearly: "This business appears to be a direct seller — standard Stripe integration may be more appropriate than Stripe Connect." Set Business Model confidence to HIGH with value "not-connect". |
+| **Conflicting signals** | Note the conflict explicitly. Set confidence to MEDIUM. Provide your best inference with reasoning about why you chose one interpretation over the other. |

--- a/providers/grok/plugin/agents/company-researcher.md
+++ b/providers/grok/plugin/agents/company-researcher.md
@@ -2,18 +2,21 @@
 name: company-researcher
 description: "Research a company from its URL or description to infer Stripe Connect integration shape"
 tools:
-  - Read
-  - Glob
-  - Grep
-  - WebFetch
-  - WebSearch
+  - read_file
+  - list_dir
+  - grep
+  - web_fetch
+  - web_search
+disallowedTools:
+  - search_tool
+  - use_tool
 ---
 
 # Company Researcher Agent
 
 Research a company using its website URL or a text description, then map findings to the Stripe Connect decision matrix. Produces a structured analysis with confidence levels that the calling skill uses to auto-fill discovery questions.
 
-You only have research tools (read/search/list/web). On Grok Build these appear as `read_file`, `grep`, `list_dir`, `web_fetch`, and `web_search` (Claude names in the frontmatter map to those). Do not attempt to write files or run shell commands.
+You only have research tools: `read_file`, `list_dir`, `grep`, `web_fetch`, and `web_search` (if enabled). Do not write files, run shell commands, spawn subagents, or use MCP (`search_tool` / `use_tool` are denied). Prefer `web_fetch` if `web_search` is unavailable.
 
 ## Inputs
 
@@ -27,20 +30,20 @@ You will receive one or both of:
 
 **If a URL is provided:**
 
-1. `WebFetch` the homepage. Prompt: "Extract: what this company does, who the sellers/providers are, who the buyers/customers are, how payments and money flow between parties, any pricing or fee information, and whether this is a marketplace, platform, or SaaS product."
+1. `web_fetch` the homepage. Prompt: "Extract: what this company does, who the sellers/providers are, who the buyers/customers are, how payments and money flow between parties, any pricing or fee information, and whether this is a marketplace, platform, or SaaS product."
 
 2. Attempt to fetch deeper pages for additional signals. Try these URL suffixes in parallel and use whatever succeeds:
    - `/about`, `/about-us`, `/how-it-works` — for business model clarity
    - `/pricing`, `/plans` — for fee structure
 
-3. If the homepage fetch fails (403, 404, timeout, empty content), fall back to `WebSearch` using the domain name plus "business model how it works".
+3. If the homepage fetch fails (403, 404, timeout, empty content), fall back to `web_search` using the domain name plus "business model how it works".
 
 **If only a description is provided (no URL):**
 
-1. `WebSearch` for the company name (if identifiable) plus "business model" and "pricing".
+1. `web_search` for the company name (if identifiable) plus "business model" and "pricing".
 2. If the description is generic (e.g. "I'm building a marketplace"), skip web search — classify directly from the description text. Maximum confidence for description-only inferences is MEDIUM.
 
-**If both `WebFetch` and `WebSearch` are unavailable or fail:**
+**If both `web_fetch` and `web_search` are unavailable or fail:**
 
 If no description text is available (URL-only input and web research failed), return the early-exit output from Step 4 with all dimensions set to LOW confidence and the note: "Web research unavailable and no description provided. Cannot perform research."
 
@@ -110,8 +113,8 @@ Return your analysis in this exact format:
 
 | Scenario | What to do |
 |----------|------------|
-| **URL returns 403/404/timeout** | Fall back to `WebSearch` with the domain name. Note in Sources: "Direct URL unreachable, used web search." |
-| **URL is a SPA with minimal HTML** | `WebFetch` may return little content. Fall back to `WebSearch`. Check meta tags and page title. |
+| **URL returns 403/404/timeout** | Fall back to `web_search` with the domain name. Note in Sources: "Direct URL unreachable, used web search." |
+| **URL is a SPA with minimal HTML** | `web_fetch` may return little content. Fall back to `web_search`. Check meta tags and page title. |
 | **Pricing is behind a login** | Fee structure confidence drops to LOW. Note: "Pricing not publicly available." |
 | **Company does multiple things** | Note the ambiguity. Classify based on the primary product. Set confidence to MEDIUM with reasoning about which facet you chose. |
 | **Not a marketplace or platform** | If the business is purely B2C with no multi-party payments, flag clearly: "This business appears to be a direct seller — standard Stripe integration may be more appropriate than Stripe Connect." Set Business Model confidence to HIGH with value "not-connect". |

--- a/providers/grok/plugin/commands/explain-error.md
+++ b/providers/grok/plugin/commands/explain-error.md
@@ -1,0 +1,21 @@
+---
+description: Explain Stripe error codes and provide solutions with code examples
+argument-hint: [error_code or error_message]
+---
+
+# Explain Stripe Error
+
+Provide a comprehensive explanation of the given Stripe error code or error message:
+
+1. Accept the error code or full error message from the arguments
+2. Explain in plain English what the error means
+3. List common causes of this error
+4. Provide specific solutions and handling recommendations
+5. Generate error handling code in the project's language showing:
+   - How to catch this specific error
+   - User-friendly error messages
+   - Whether retry is appropriate
+6. Mention related error codes the developer should be aware of
+7. Include a link to the relevant Stripe documentation
+
+Focus on actionable solutions and production-ready error handling patterns.

--- a/providers/grok/plugin/commands/test-cards.md
+++ b/providers/grok/plugin/commands/test-cards.md
@@ -1,0 +1,24 @@
+---
+description: Display Stripe test card numbers for various testing scenarios
+argument-hint: [scenario]
+---
+
+# Test Cards Reference
+
+Provide a quick reference for Stripe test card numbers:
+
+1. If a scenario argument is provided (e.g., "declined", "3dsecure", "fraud"), show relevant test cards for that scenario
+2. Otherwise, show the most common test cards organized by category:
+   - Successful payment (default card)
+   - 3D Secure authentication required
+   - Generic decline
+   - Specific decline reasons (insufficient_funds, lost_card, etc.)
+3. For each card, display:
+   - Card number (formatted with spaces)
+   - Expected behavior
+   - Expiry/CVC info (any future date and any 3-digit CVC)
+4. Use clear visual indicators (✓ for success, ⚠️ for auth required, ✗ for decline)
+5. Mention that these only work in test mode
+6. Provide link to full testing documentation: https://docs.stripe.com/testing.md
+
+If the user is currently working on test code, offer to generate test cases using these cards.

--- a/providers/grok/plugin/skills/connect-recommend/SKILL.md
+++ b/providers/grok/plugin/skills/connect-recommend/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: connect-recommend
+description: >-
+  This skill should be used when the user asks about Stripe Connect configuration, charge patterns, dashboard access, or how to get started with Connect,
+  is building a marketplace, platform, multi-vendor store, gig platform, or subscription platform,
+  needs to pay out sellers, vendors, or providers,
+  mentions split payments, revenue sharing, multi-party payments, or similar payment distribution concepts,
+  provides a company URL or business description for a recommendation,
+  builds SaaS that routes money between parties (e.g. POS, booking, invoicing — not operational SaaS without payment routing),
+  asks about onboarding or KYC for merchants/sellers/vendors,
+  mentions connected account dashboard or responsibility configurations,
+  or asks about payment flows, white-label payments, or embedded payments.
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+  - Edit
+  - Bash
+  - AskUserQuestion
+  - Task
+---
+
+# Connect Recommend
+
+Recommend the right Stripe Connect integration shape. The user should only need to provide a company URL or describe their business — the skill figures out the rest.
+
+## Interaction Model
+
+**AskUserQuestion is the primary interaction tool** (Grok Build: `ask_user_question`). Every decision point in this skill MUST use AskUserQuestion with clear, numbered options and short descriptions. One question at a time — never overwhelm the user.
+
+**Auto-act on low-cost actions.** Never ask permission for:
+- Generating the markdown recommendation plan — just generate it
+- Scanning the codebase — just scan it
+- Reading reference files — just read them
+
+**Never end with passive text.** Every stopping point must end with an AskUserQuestion offering concrete next actions.
+
+## Terminology rules (user-facing output)
+
+**Before generating any user-facing output, read `${SKILL_DIR}/references/terminology-rules.md`.**
+Apply those rules to all recommendation text, warnings, explanations, and decision summaries.
+
+Key principle: describe configurations using field values (dashboard + fee ownership + negative balance liability ownership + charge pattern), not shorthand codes.
+
+## Output Brevity
+
+Keep responses concise. The user is making decisions, not reading documentation.
+
+- Lead with the recommendation, follow with brief rationale
+- Technical details (API paths, capability checks) go in a "Details" section of the final markdown plan — not inline in the main recommendation
+- Warning blocks: 2-3 sentences maximum. State the issue and the fix. No mechanism deep-dives unless the user asks.
+- Decision summary: bullet points only, one line per decision
+- Never output more than ~40 lines in a single response during interactive mode
+
+**Only surface out-of-scope limitations when they are directly relevant to what the user asked about.** Do not proactively list constraints or unsupported features (e.g., OAuth, international expansion) when the user has not asked about them. "Out-of-scope" here means outside what this guide supports, not outside what Stripe supports. Research these topics in Stripe's public documentation (docs.stripe.com) rather than saying they're out-of-scope.
+
+## Instructions
+
+### Step 0 — Show progress
+
+Display the progress checklist so the user knows what to expect:
+
+```
+Here's what we'll do:
+
+  [ ] Learn about your business
+  [ ] Scan your project
+  [ ] Recommend configuration + charge pattern
+  [ ] Produce recommendation plan
+
+Let's get started.
+```
+
+### Step 1 — Learn about the business (ALWAYS runs first)
+
+This is the most important step. Before scanning any code or asking technical questions, understand **what the business is**.
+
+**1a. Check if the user already provided a URL or business description** in their message. Look for:
+- A URL (e.g. `https://...`, `www.`, `.com`, `.io`)
+- A business description (e.g. "I'm building a marketplace for...", "We connect freelancers with...")
+- A company name that can be searched
+
+**1b. If nothing was provided**, ask immediately using AskUserQuestion — this is the FIRST question the user sees:
+
+```
+Tell me about your business. Pick whichever is easiest:
+```
+
+Options:
+- "I have a URL" — user provides URL, then research it
+- "Let me describe it" — user provides description, then research it
+- "Just scan my codebase" — skip to Step 2, rely on codebase signals only
+- "Skip — ask me questions instead" — skip to Step 3 with full questionnaire
+
+**1c. Research the business** — spawn the Company Researcher subagent:
+
+Use the `Task` tool (Grok Build: `spawn_subagent`) with:
+- `subagent_type`: `"Company Researcher"` (if that type is unavailable or ambiguous, use `"stripe:Company Researcher"`)
+- `description`: short label, e.g. `"Research company for Connect shape"`
+- `prompt`: include the company URL and/or business description the user provided. Do **not** ask the subagent to read agent definition files — its system prompt is already the Company Researcher agent. Do **not** use `general-purpose` for this step.
+
+The agent is tool-scoped to research only (read/search/web). It returns a structured analysis with confidence levels (HIGH/MEDIUM/LOW) for each decision dimension.
+
+**1d. Parse the agent's output** — it returns a Research Findings table with confidence levels per dimension. Read the decision matrix at `${SKILL_DIR}/references/decision-matrix.md` and map the findings to a recommended configuration. Then determine pre-fill behavior per dimension:
+- **HIGH confidence**: Auto-fill — do not ask about this dimension
+- **MEDIUM confidence**: Suggest the inferred value and ask for quick confirmation
+- **LOW confidence**: Ask the original open-ended question in Step 3
+
+**1e. Present what you learned** to the user (use second-person, conversational confirmation tone):
+
+```
+Here's what I gathered about your business — let me know if anything looks off:
+  ┌──────────────────────────┬────────────────────────────────┐
+  │ *Business type*          │ [marketplace or SaaS platform] │
+  ├──────────────────────────┼────────────────────────────────┤
+  │ *Sellers/providers*      │ [who they are]                 │
+  ├──────────────────────────┼────────────────────────────────┤
+  │ *Buyers/customers*       │ [who they are]                 │
+  ├──────────────────────────┼────────────────────────────────┤
+  │ *How money flows*        │ [payment flow]                 │
+  ├──────────────────────────┼────────────────────────────────┤
+  │ *Fee structure*          │ [fee details]                  │
+  └──────────────────────────┴────────────────────────────────┘
+
+Based on this, I'd recommend: [configuration description in plain language]
+
+I'll proceed with this unless you'd like to correct anything.
+```
+
+For MEDIUM confidence items, append: "I'm also assuming [X] — sound right?"
+
+If the agent flags "not-connect" (business doesn't need Connect), use AskUserQuestion:
+
+```
+Based on my research, your business may not need Stripe Connect — a standard Stripe integration might be a better fit.
+```
+
+Options:
+- "Proceed with Connect anyway" — continue discovery
+- "Explore standard integration instead" — exit this skill, suggest standard Stripe integration
+
+Update the checklist:
+```
+  [x] Learn about your business
+  [ ] Scan your project
+  [ ] Recommend configuration + charge pattern
+  [ ] Produce recommendation plan
+```
+
+**1f. Validate fee economics (ALWAYS runs, even on auto-filled values)**
+
+If the platform fee (from auto-fill or user input) appears low AND any of these conditions apply:
+- Charge pattern is `destination` or `separate` (platform pays Stripe fees by default)
+- Charge pattern is `direct` AND `fees_collector: "application"` (platform still pays Stripe fees)
+
+Then:
+- ALWAYS show a margin warning regardless of how the fee was obtained
+- Warn: "Your platform fee may be below Stripe's processing fees at standard rates. Since the platform pays Stripe's processing fees with destination charges, your net margin could be very thin or negative. Check [stripe.com/pricing](https://stripe.com/pricing) for your region's rates."
+- Strongly recommend: calculating `application_fee_amount` as platform fee + estimated Stripe processing fee (so the platform's margin is preserved) and (if platform owns pricing) using the [Platform Pricing Tool](https://dashboard.stripe.com/settings/connect/platform_pricing)
+- Recommend monitoring the [margin report](https://docs.stripe.com/connect/margin-reports) in the Stripe Dashboard
+
+This check MUST run even when the fee was auto-filled with HIGH confidence. The user needs to understand the fee economics before proceeding.
+
+### Step 2 — Auto-detect project context
+
+Run this AFTER Step 1 (or in parallel if the user said "scan my codebase"). Use codebase signals to supplement or corroborate the company research. **Do not ask before scanning — just scan.**
+
+1. **Existing Connect config**: Check for `connect-recommend-plan.md` or any file at the project root that resembles a prior recommendation plan (e.g., contains `## Recommended Connect integration plan`). If found, read it and note the prior configuration — use it to pre-fill or validate decisions in later steps, and surface it to the user before asking questions they've already answered.
+2. **Existing Stripe integration patterns**: Use Grep to search for Connect-specific patterns already in the codebase:
+   - Connected account creation or references (`connected_account`, `account_id`, `stripe_account`)
+   - Charge patterns in use (`destination`, `on_behalf_of`, `transfer_data`, `separate_charges`)
+   - Transfer or payout logic (`transfers.create`, `payouts.create`)
+   - Webhook handlers for Connect events (`account.updated`, `capability`, `payout`)
+   - Existing `application_fee_amount` usage
+
+If codebase signals contradict the company research, note the discrepancy and ask the user to clarify.
+
+Present findings briefly (don't repeat what Step 1 already covered):
+```
+Project scan:
+- Existing Connect plan: [found at path / not found]
+- Existing Connect integration: [patterns found / not found]
+```
+
+If a prior plan was found, use AskUserQuestion:
+```
+I found an existing Connect recommendation plan at [path].
+```
+Options:
+- "Use it as a starting point" — pre-fill all decisions from the prior plan, then confirm each with the user in Step 3
+- "Start fresh" — ignore the prior plan and run full discovery
+
+Update the checklist:
+```
+  [x] Learn about your business
+  [x] Scan your project
+  [ ] Recommend configuration + charge pattern
+  [ ] Produce recommendation plan
+```
+
+### Step 3 — Ask remaining discovery questions
+
+For any dimension not already filled with HIGH confidence from Step 1, ask the corresponding question using AskUserQuestion. Skip dimensions that were auto-filled or explicitly confirmed.
+
+**Read `${SKILL_DIR}/references/discovery-questions.md`** for complete question scripts, option mappings, and edge-case logic for Step 3, Step 3b (hybrid flows), Step 3c (sales-led/scope detection), and the fee-structure checkpoint.
+
+If Step 1 was skipped entirely, ask all six discovery questions one at a time:
+- Q1: Business model
+- Q2: Parties in the platform
+- Q3: Payment flow
+- Q4: Dashboard and onboarding preference
+- Q5: Dispute/refund ownership + risk management + loss liability
+- Q6: Fee structure + `application_fee_amount` calculation
+
+Critical guardrails (must enforce in all discovery paths):
+- For marketplace/intermediary checkout flows, default to destination charges unless behavior clearly indicates each seller runs their own checkout/payment relationship.
+- If the business mixes own-brand sales with marketplace/intermediary flows, trigger Step 3b hybrid-flow handling and map each flow to its own charge-pattern and responsibility settings.
+- If the user needs hold-and-release timing, recommend separate charges and transfers (destination charges cannot hold funds and are not appropriate for hold-and-release behavior).
+- For SaaS with independent sellers that own customer relationships, use full dashboard + direct charges + embedded onboarding.
+- If the user asks "what account type should I use?", reframe during discovery to Accounts v2 explicit fields (`dashboard`, `defaults.responsibilities`, and `merchant`/`recipient` by funds flow), not legacy account types.
+- When describing low-margin scenarios, present warning/risk before mitigation steps.
+- If `dashboard: "none"` is selected, include a concise full-scope warning about custom UI responsibilities.
+- For destination/separate recommendations with `losses_collector: "application"`, explain the causal chain: platform owns negative balance liability and connected-account negative balances enable dispute-time transfer reversals.
+- Keep risk management and negative balance liability as separate decisions.
+- Trigger Step 3c when enterprise/sales-led signals appear (`on_behalf_of`, cross-border complexity, non-Connect products, or sales-gated configs).
+
+Fee structure checkpoint before Step 4:
+1. Confirm fee type and fee amount
+2. Confirm how `application_fee_amount` is calculated
+3. Confirm whether a margin warning is required
+4. Include stripe.com/pricing link in output context
+
+### Step 4 — Generate recommendation
+
+Read the decision matrix at `${SKILL_DIR}/references/decision-matrix.md` and apply it to the user's answers.
+
+**Step 4a — Compatibility validation (MANDATORY before presenting recommendation)**
+
+Read `${SKILL_DIR}/references/compatibility-matrix.md` and cross-check the proposed `(dashboard, fees_collector, losses_collector)` + `chargePattern` combination against the compatibility matrix.
+
+1. **BLOCKED combination?** Do NOT present it. Output a visible BLOCKED warning with ALL of these:
+   - The exact blocked config tuple (e.g., `losses_collector: "stripe" + destination charges`)
+   - A 2-3 sentence explanation of the MECHANISM of failure (e.g., "With destination charges, when a customer disputes a charge, Stripe reverses the transfer from the connected account. If losses_collector is 'stripe', the connected account's balance can go negative — but the platform silently carries this liability despite the config saying Stripe is responsible.")
+   - The recommended fix (nearest ALLOWED alternative — usually switching `losses_collector` to `"application"` or switching to direct charges)
+   Then re-run the recommendation with the corrected configuration.
+
+2. **CAUTION combination?** Present the recommendation but include a visible warning callout explaining the specific tradeoff (e.g., "dashboard visibility limitations for direct charges when using `dashboard: \"express\"`").
+
+3. **Additional compatibility checks (include concise warnings when triggered):**
+   - If the user mentioned **OAuth** for connecting accounts, include a 1-2 sentence warning that accounts can disconnect and recommend embedded onboarding for stronger platform control.
+   - If `dashboard: "none"`, include a concise warning that the platform must own onboarding/remediation, refund/dispute flows, and earnings/payout surfaces; recommend Express dashboard with embedded components as a lower-maintenance alternative.
+   - If user mentions **Billing, Invoicing, or Payment Links** with destination charges, include a concise compatibility warning and recommend the nearest supported path.
+   - If `dashboard: "full"` + charge pattern is `destination` or `separate`, include a concise warning that full dashboard is optimized for direct charges and recommend switching dashboard type or charge pattern.
+   - If `dashboard: "express"` + `fees_collector: "stripe"`, treat as BLOCKED and recommend either switching to full dashboard (Stripe-owned pricing) or platform-owned pricing.
+
+4. **Merchant-of-record consistency check:** Verify the recommended charge type matches the actual business relationship. Direct charges = connected account provides goods/services directly. Destination/separate charges and transfers = platform owns the customer relationship. Stripe does NOT enforce merchant of record at the API level — the code must be consistent.
+
+5. **Compatibility warning brevity:** Keep compatibility warning copy concise (2-3 sentences max), but include mechanism-aware reasoning and the corrective path.
+
+**Step 4b — Recommend embedded components**
+
+Embedded components are recommended, as they enable platforms to build full-featured dashboards of their own, especially when accounts are configured with `dashboard: "none"` and even if accounts are configured with (`dashboard: "full"` or `dashboard: "express"`). Select components based on user needs:
+
+Baseline (always include):
+- `account_onboarding`
+- `notification_banner` (required; keeps connected accounts healthy/enabled as requirements evolve)
+- `account_management`
+
+Common additions:
+- Transaction history → `payments` (use `payment_details` if building a custom payments list)
+- Disputes → included with `payments` but can use `disputes_list` if also building a standalone disputes page
+- Payout operations/earnings → `payouts`
+- Reporting/reconciliation → `balance_report`, `payout_reconciliation_report`
+
+Charge-pattern compatibility caveats:
+- Destination charges (without `on_behalf_of`): payment/dispute surfaces show reduced detail. The `destination_on_behalf_of_charge_management` setting does not apply to plain destination charges.
+- Destination charges with `on_behalf_of`: payment/dispute surfaces show reduced detail unless `destination_on_behalf_of_charge_management` is enabled. This setting applies only to destination charges that use the `on_behalf_of` parameter — not plain destination charges or separate charges.
+- Separate charges and transfers: payment/dispute surfaces show reduced detail. There is no equivalent management setting for this charge pattern.
+- Direct: payment/dispute surfaces operate with full fidelity.
+
+When recommending payment or dispute components with destination charges that use `on_behalf_of`, add:
+"Enable `destination_on_behalf_of_charge_management` only if the platform is using destination charges with `on_behalf_of` and wants their connected accounts to view payment details, manage refunds, or manage disputes, and the integration handles the required transfer reversals when there are disputes. This applies only to destination charges with the `on_behalf_of` parameter, not plain destination charges or separate charges."
+
+Out of scope component families:
+- Issuing/Treasury/Capital/Tax component sets (route through Step 3c scope handling).
+
+Be prepared to output a list of embedded components in the next step.
+
+Update the checklist:
+```
+  [x] Learn about your business
+  [x] Scan your project
+  [x] Recommend configuration + charge pattern
+  [ ] Produce recommendation plan
+```
+
+### Step 5 — Generate recommendation plan
+
+**Read `${SKILL_DIR}/references/recommendation-template.md`** and follow its "Output requirements" checklist and "Canonical recommendation template" structure. That file is the single source of truth for required sections, wording, and formatting. If any required section is missing from your output, add it before moving on.
+
+Then use AskUserQuestion:
+```
+Does this recommendation look right?
+```
+Options (max 4 — AskUserQuestion hard limit):
+- "Looks good" — proceed to Step 6
+- "Change something" — ask which aspect to change (dashboard/responsibility settings, charge pattern, fee structure, or fee calculation) then re-ask the relevant question
+- "Explain more about the options" — read reference docs and explain alternatives
+
+Generate the final recommendation plan. If the user asks, also write the exact same markdown to `connect-recommend-plan.md` at the project root.
+
+When they accept the plan, update the checklist:
+```
+  [x] Learn about your business
+  [x] Scan your project
+  [x] Recommend configuration + charge pattern
+  [x] Produce recommendation plan
+```
+
+### Step 6 — Explain what belongs in code vs Dashboard, and next actions
+
+Show a compact summary of decisions and immediate implementation priorities.
+
+Briefly explain:
+- **In your code**: charge pattern behavior, `application_fee_amount` math, transfer/reversal handling, and webhook handlers
+- **In Stripe Dashboard**: platform profile settings, pricing tool configuration, connected-account visibility, Radar for Platforms settings, and operational monitoring
+- **During onboarding/runtime**: capability activation, payouts readiness, and account-state transitions
+
+**IMPORTANT: Always end with AskUserQuestion.** Never end with passive text.
+
+Use AskUserQuestion:
+```
+What would you like to do next?
+```
+Options:
+- "Refine a decision" — adjust dashboard, responsibilities, charge pattern, or fee model
+- "Expand implementation steps" — provide a deeper technical rollout checklist
+- "Generate `connect-recommend-plan.md` and build" — write the plan to a markdown file and handoff to a coding agent

--- a/providers/grok/plugin/skills/connect-recommend/SKILL.md
+++ b/providers/grok/plugin/skills/connect-recommend/SKILL.md
@@ -93,12 +93,12 @@ Options:
 - "Just scan my codebase" — skip to Step 2, rely on codebase signals only
 - "Skip — ask me questions instead" — skip to Step 3 with full questionnaire
 
-**1c. Research the business** — spawn the Company Researcher subagent:
+**1c. Research the business** — spawn the `company-researcher` subagent:
 
 Use the `Task` tool (Grok Build: `spawn_subagent`) with:
-- `subagent_type`: `"Company Researcher"` (if that type is unavailable or ambiguous, use `"stripe:Company Researcher"`)
+- `subagent_type`: `"company-researcher"` (if that type is unavailable or ambiguous, use `"stripe:company-researcher"`)
 - `description`: short label, e.g. `"Research company for Connect shape"`
-- `prompt`: include the company URL and/or business description the user provided. Do **not** ask the subagent to read agent definition files — its system prompt is already the Company Researcher agent. Do **not** use `general-purpose` for this step.
+- `prompt`: include the company URL and/or business description the user provided. Do **not** ask the subagent to read agent definition files — its system prompt is already the company-researcher agent. Do **not** use `general-purpose` for this step.
 
 The agent is tool-scoped to research only (read/search/web). It returns a structured analysis with confidence levels (HIGH/MEDIUM/LOW) for each decision dimension.
 

--- a/providers/grok/plugin/skills/connect-recommend/references/account-types.md
+++ b/providers/grok/plugin/skills/connect-recommend/references/account-types.md
@@ -1,0 +1,226 @@
+# Stripe Connect Account Configuration (Accounts v2)
+
+> **IMPORTANT: Use Accounts v2 API**
+>
+> Do NOT use the legacy `type` parameter (`standard`, `express`, `custom`) when creating connected accounts. These are v1 terms and are no longer the recommended path. Instead, use the Accounts v2 API (`stripe.v2.core.accounts`) and configure each account along three independent dimensions: **dashboard access**, **fee collection**, and **loss liability**. This gives platforms precise control without being locked into a rigid archetype.
+
+---
+
+## Account Configuration Dimensions
+
+Accounts v2 replaces the three fixed account types with three independent configuration dimensions. Each dimension is set separately, so platforms can mix and match to fit their exact business model.
+
+### 1. Dashboard access (`dashboard`)
+
+Controls what connected accounts see when they log in.
+
+| Value | Experience | Use when |
+|-------|-----------|----------|
+| `express` | Lightweight dashboard showing earnings, payouts, and basic tax info. Stripe-branded with platform name. | Marketplace sellers, gig workers, or any connected account that needs visibility but not full Stripe control. |
+| `full` | Full, independent Stripe Dashboard. Connected accounts can manage their own settings, view all transactions, and install apps. | SaaS platforms where connected accounts are established businesses that want to operate independently. |
+| `none` | No Stripe dashboard. The platform owns the UI experience — use **[Embedded Components](https://docs.stripe.com/connect/supported-embedded-components)** (`@stripe/connect-js`) for pre-built widgets (account management, payouts, tax forms, etc.) or build fully custom. | White-label platforms where connected accounts must never see Stripe branding. Use embedded components for pre-built functionality with white-label feel. **Fully custom (no embedded components)** adds significant complexity — the platform must build and maintain all connected account UX including onboarding remediation, refund/dispute flows, and ongoing requirement collection. |
+
+### 2. Fee collection (`defaults.responsibilities.fees_collector`)
+
+Determines who is responsible for collecting Stripe processing fees from connected accounts.
+
+| Value | Behavior | Use when |
+|-------|----------|----------|
+| `stripe` | Stripe bills connected accounts directly for processing fees. The platform does not need to handle fee logistics. | Most platforms. Simpler to operate. Connected accounts see Stripe fees on their own statements. |
+| `application` | The platform is responsible for collecting fees from connected accounts and remitting them to Stripe. The platform receives a single invoice from Stripe. | Enterprise or white-label platforms that want full control over billing relationships, or that bundle Stripe fees into their own pricing. |
+
+> **Fee collection behavior depends on charge type.** The `fees_collector` setting interacts with the charge pattern:
+> - **Direct charges:** `fees_collector` determines who pays Stripe processing fees. With `fees_collector: "stripe"`, the connected account pays fees directly. The `fee_payer` parameter can further control this — see [direct charges fee payer behavior](https://docs.stripe.com/connect/direct-charges-fee-payer-behavior).
+> - **Destination charges / separate charges and transfers:** The platform always pays Stripe processing fees regardless of the `fees_collector` setting, because the charge lives on the platform account. The `fees_collector` setting in these cases governs the platform-level billing relationship with Stripe (single invoice vs per-account), not per-transaction fee deduction.
+
+### 3. Loss liability (`defaults.responsibilities.losses_collector`)
+
+Determines who bears financial responsibility for negative balances, disputes, and refunds on connected account activity.
+
+| Value | Behavior | Use when |
+|-------|----------|----------|
+| `stripe` | Stripe bears financial responsibility for negative balances on connected accounts that remain unresolved (e.g., from disputes or fraud). | Most platforms. Reduces financial risk from unrecoverable negative balances. |
+| `application` | The platform bears losses from unresolved negative balances, and is responsible for managing disputes. | Platforms with sophisticated risk management, high-risk verticals, or those that want to internalize loss economics for better unit economics. |
+
+---
+
+## Common Configurations
+
+| Business Shape | Dashboard | Fees Collector | Losses Collector | Notes |
+|---------------|-----------|---------------|-----------------|-------|
+| **Marketplace** | `express` | `application` | `application` | Platform owns fees and losses. Sellers get a lightweight dashboard. Required for Express dashboard + destination charges. Common for two-sided marketplace models. |
+| **SaaS enabling payments** | `full` | `stripe` | `stripe` | Connected accounts are independent businesses with their own Stripe experience. Platform collects revenue via application fees. **Use direct charges only** — other charge types with `losses_collector: 'stripe'` cause the platform to silently carry negative balance liabilities. |
+| **White-label / enterprise** | `none` | `application` | `application` | Platform owns the entire experience. No Stripe branding. Platform manages all billing and risk. Full control with higher operational responsibility. Compatible with all charge types. |
+| **Managed marketplace** | `express` | `application` | `application` | Platform wants seller-facing dashboard and also owns risk. Express dashboard requires platform to own both fees and losses. Compatible with all charge types. |
+| **Embedded SaaS** | `none` | `stripe` | `stripe` | Stripe bills connected accounts for fees and bears unresolved negative balances. Connected accounts will have very limited exposure to Stripe branding and Stripe surfaces. **Use direct charges only** — `losses_collector: 'stripe'` is incompatible with destination charges and separate charges and transfers. **Not the standard automated SaaS path.** Standard SaaS uses `full` + `stripe` + `stripe`. With this configuration, the platform owns the UI experience using embedded components rather than giving connected accounts a Stripe-hosted dashboard. |
+
+### Configuration Compatibility Warnings
+
+> **CRITICAL: `losses_collector: 'stripe'` restricts you to direct charges only.**
+>
+> When Stripe owns loss liability but the platform uses destination charges, separate charges and transfers, or `on_behalf_of` variants, the liability model does not align with how these charge flows are debited and recovered. See `compatibility-matrix.md` for the full compatibility matrix.
+
+Key rules:
+- **Express dashboard** requires `fees_collector: 'application'` AND `losses_collector: 'application'`
+- **`losses_collector: 'stripe'` + destination charges or separate charges and transfers** = BLOCKED. Platform silently inherits negative balance liability, fees are misattributed, and connected accounts cannot manage refunds/disputes from their dashboard.
+- **`losses_collector: 'application'`** is compatible with all charge types
+- **`dashboard: "full"` + `fees_collector: "application"`** = SALES-GATED. Do NOT recommend for self-serve paths. Redirect to [Stripe sales](https://stripe.com/contact/sales).
+
+---
+
+## v2 API Example
+
+Create a connected account using Accounts v2:
+
+**Marketplace connected account (destination charges or separate charges and transfers):**
+
+```javascript
+const account = await stripe.v2.core.accounts.create({
+  contact_email: 'seller@example.com',
+  display_name: 'Seller Name',
+  dashboard: 'express',
+  identity: { country: 'us', entity_type: 'individual' },
+  configuration: {
+    recipient: {
+      capabilities: {
+        stripe_balance: { stripe_transfers: { requested: true } },
+      },
+    },
+  },
+  defaults: {
+    currency: 'usd',
+    responsibilities: {
+      fees_collector: 'application',
+      losses_collector: 'application',
+    },
+  },
+});
+```
+
+**SaaS connected account (direct charges):**
+
+```javascript
+const account = await stripe.v2.core.accounts.create({
+  contact_email: 'merchant@example.com',
+  display_name: 'Merchant Name',
+  dashboard: 'full',
+  identity: { country: 'us', entity_type: 'individual' },
+  configuration: {
+    merchant: {
+      capabilities: {
+        card_payments: { requested: true },
+      },
+    },
+  },
+  defaults: {
+    currency: 'usd',
+    responsibilities: {
+      fees_collector: 'stripe',
+      losses_collector: 'stripe',
+    },
+  },
+});
+```
+
+Key points about this API:
+
+- **`dashboard`** is set at the top level, not inside configuration.
+- **`identity.country`** and **`identity.entity_type`** replace the old `country` and `business_type` fields.
+- For marketplace connected accounts: use `configuration.recipient` with `stripe_balance.stripe_transfers` — do NOT request `configuration.merchant` or `card_payments` (unnecessary and causes longer onboarding).
+- For SaaS connected accounts: use `configuration.merchant` with `card_payments` — the connected account is merchant of record (i.e., direct charges where the connected account's name appears on customer bank statements).
+- **`defaults.responsibilities`** is where you set fee and loss liability. These are the v2 replacements for what was previously implied by account type.
+- **`defaults.currency`** sets the default settlement currency.
+
+### Merchant Configuration (Required for Merchant of Record)
+
+> **For SaaS/direct charges only.** Marketplace connected accounts should use `configuration.recipient` instead — see example above.
+
+In Accounts v2, the `configuration.merchant` block is what makes a connected account capable of accepting payments as the merchant of record. This is required when using **direct charges** (where the charge is created on the connected account and their business name appears on customer bank statements).
+
+Without the Merchant configuration, the connected account cannot process payments directly — it can only receive transfers from the platform.
+
+```javascript
+configuration: {
+  merchant: {
+    capabilities: {
+      card_payments: { requested: true },
+      transfers: { requested: true },
+    },
+  },
+},
+```
+
+**When to include Merchant configuration:**
+- **Direct charges** — REQUIRED. The connected account is the merchant of record.
+- **Destination charges** — Optional but recommended. The platform is merchant of record, but connected accounts still need `transfers` capability to receive payouts.
+- **Separate charges & transfers** — Optional. Only the platform creates charges; connected accounts receive transfers.
+
+---
+
+## Decision Guide
+
+**Choose `dashboard: 'express'` when...**
+- You are building a marketplace or on-demand platform
+- Connected accounts need to see their earnings and payout history
+- You want Stripe to handle the dashboard experience so you can focus on your product
+- You want fast onboarding with Stripe-hosted flows
+
+**Choose `dashboard: 'full'` when...**
+- Connected accounts are established businesses that expect a full payments dashboard
+- You are a SaaS platform where merchants operate independently
+- Connected accounts may want to install Stripe apps or manage their own settings
+- Sellers already have or expect to have their own Stripe relationship
+
+**Choose `dashboard: 'none'` when...**
+- You need a fully white-labeled experience with zero Stripe branding
+- Connected accounts should never interact with a Stripe-hosted dashboard
+- The platform wants to take on more responsibility: must support ongoing requirement collection, and refund/dispute flows (can use embedded components)
+- **Fully custom (no embedded components)** adds significant complexity — the platform must build and maintain all connected account UX including onboarding remediation, refund/dispute flows, and ongoing requirement collection
+
+**Choose `losses_collector: 'stripe'` when...**
+- You want Stripe to bear financial responsibility for unresolved negative balances on connected accounts
+- You are starting out and want to minimize financial risk
+- You do not have a dedicated risk or fraud operations team
+- You plan to use direct charges or destination charges with on_behalf_of
+
+**Choose `losses_collector: 'application'` when...**
+- You have a mature risk management operation
+- You want to internalize loss economics (e.g., you believe your fraud rate is low enough to profit from self-insuring)
+- You operate in a vertical where you have better risk signal than Stripe
+- You need full control over dispute response workflows
+- You plan to use destination charges or separate charges and transfers, and on_behalf_of is not used
+
+**Choose `fees_collector: 'stripe'` when...**
+- You want the simplest operational model
+- You are fine with Stripe billing connected accounts directly
+- You do not want to manage fee invoicing or reconciliation
+
+**Choose `fees_collector: 'application'` when...**
+- You want to control the entire billing relationship with connected accounts
+- You bundle Stripe processing fees into your own platform pricing
+- You need consolidated invoicing from Stripe to your platform
+
+---
+
+## Legacy Migration Note
+
+The terms **Standard**, **Express**, and **Custom** refer to the v1 Accounts API and its `type` parameter. They are no longer the recommended way to create connected accounts. Here is how they roughly map to v2 dimensions:
+
+| Legacy v1 Type | Approximate v2 Equivalent |
+|---------------|--------------------------|
+| Standard | `dashboard: 'full'`, `fees_collector: 'stripe'`, `losses_collector: 'stripe'` |
+| Express | `dashboard: 'express'`, `fees_collector: 'application'`, `losses_collector: 'application'` |
+| Custom | `dashboard: 'none'`, `fees_collector: 'application'`, `losses_collector: 'application'` |
+
+The mapping is approximate — v2 allows combinations that were impossible in v1, and legacy types have behavioral nuances that don't carry over to their v2 "equivalents." For example, the fee payer behavior in the approximate v2 config equivalent is different from what the legacy type provided.
+
+Stripe docs also expose legacy fee-payer variants for direct charges:
+
+| Legacy fee-payer value (docs) | Meaning |
+|-------------------------------|---------|
+| `application_express` | Historical billing behavior for legacy Express accounts |
+| `application_custom` | Historical billing behavior for legacy Custom accounts |
+
+These are external Stripe-doc terms tied to legacy account behavior. For new integrations, use Accounts v2 responsibilities (`fees_collector`, `losses_collector`) instead.
+
+Do not treat this table as "these are the same thing." It is a rough conceptual guide. Legacy accounts retain their original behaviors; v1 and v2 coexist. All new integrations should use v2.

--- a/providers/grok/plugin/skills/connect-recommend/references/charge-patterns.md
+++ b/providers/grok/plugin/skills/connect-recommend/references/charge-patterns.md
@@ -1,0 +1,300 @@
+# Stripe Connect Charge Patterns
+
+## Overview
+
+Connect offers three ways to create charges involving connected accounts. The charge pattern determines who is the merchant of record, how funds flow, and how fees/refunds work.
+
+## Comparison Table
+
+| Feature | Direct Charges | Destination Charges | Separate Charges & Transfers |
+|---------|---------------|--------------------|-----------------------------|
+| **Merchant of record** | Connected account | Platform | Platform |
+| **Payment created on** | Connected account | Platform account | Platform account |
+| **Statement descriptor** | Connected account's | Platform's (can set connected account's) | Platform's |
+| **Platform fee** | `application_fee_amount` | `application_fee_amount` or calculate via `transfer_data.amount` | Manual calculation |
+| **Refund source** | Connected account's balance | Platform's balance | Platform's balance |
+| **Multi-seller split** | No (one seller per charge) | No (one destination per charge) | Yes (multiple transfers) |
+| **Account requirements** | Any v2 config (required when `losses_collector: 'stripe'`) | Requires `losses_collector: 'application'` | Requires `losses_collector: 'application'` |
+| **Complexity** | Low | Low | High |
+| **Best for** | SaaS, seller-owned transactions | Marketplaces, on-demand | Multi-seller carts, complex splits |
+
+---
+
+## Direct Charges
+
+> **Controller Property Compatibility:** Works with ALL controller property combinations. This is the **only** charge type safe with `losses_collector: 'stripe'`. If the platform wants Stripe to own losses, direct charges are the only option.
+
+### How it works
+The charge is created directly on the connected account. The connected account is the merchant of record — their name appears on the customer's bank statement. The platform collects an application fee.
+
+### Code pattern
+```javascript
+// Backend: Create PaymentIntent on connected account
+const paymentIntent = await stripe.paymentIntents.create({
+  amount: 10000, // $100.00
+  currency: 'usd',
+  application_fee_amount: 1500, // $15.00 platform fee
+  metadata: {
+    orderId: 'order_123',
+  },
+}, {
+  stripeAccount: 'acct_connected_account_id', // Key: stripeAccount header
+});
+
+// Return client_secret to frontend
+res.json({ clientSecret: paymentIntent.client_secret });
+```
+
+### Frontend (with Stripe.js)
+```javascript
+// Must initialize Stripe with connected account
+const stripe = await loadStripe('pk_test_...', {
+  stripeAccount: 'acct_connected_account_id',
+});
+
+// Then confirm payment as usual
+const result = await stripe.confirmPayment({
+  elements,
+  confirmParams: {
+    return_url: 'https://yoursite.com/success',
+  },
+});
+```
+
+### Fund flow
+```
+Customer pays $100
+  → $100 lands in connected account's balance
+  → $15 application fee transferred to platform
+  → Connected account keeps $85
+```
+
+### Refunds
+```javascript
+// Refund comes from connected account's balance
+const refund = await stripe.refunds.create({
+  charge: 'ch_xxx',
+  // Optionally refund the application fee too:
+  refund_application_fee: true,
+}, {
+  stripeAccount: 'acct_connected_account_id',
+});
+```
+
+### When to use
+- Direct-charge integrations where sellers own the customer relationship (legacy v1 Standard-style pattern)
+- SaaS platforms (Shopify model)
+- When the connected account's name should appear on bank statements
+- When sellers handle their own disputes
+
+> **Legacy mapping note (external docs terms):** Stripe docs still reference legacy v1 naming (`standard`, `express`, `custom`) and legacy fee-payer behaviors (`application_express`, `application_custom`) for older accounts. For migration mapping to Accounts v2 dimensions, see `account-types.md` ("Legacy migration note").
+
+---
+
+## Destination Charges
+
+> **Controller Property Compatibility:** REQUIRES `losses_collector: 'application'`. Using destination charges with `losses_collector: 'stripe'` creates a liability-model mismatch for this charge flow. See `compatibility-matrix.md` for details.
+
+### How it works
+The charge is created on the platform's account. The platform is the merchant of record. Funds are automatically transferred to the connected account via `transfer_data`. This is a common pattern for marketplaces.
+
+### Code pattern
+```javascript
+// Backend: Create PaymentIntent on platform account
+const paymentIntent = await stripe.paymentIntents.create({
+  amount: 10000, // $100.00
+  currency: 'usd',
+  application_fee_amount: 1500, // $15.00 platform keeps
+  transfer_data: {
+    destination: 'acct_connected_account_id', // Funds go here
+  },
+  metadata: {
+    bookingId: 'booking_123',
+    riderId: 'user_456',
+    operatorId: 'user_789',
+  },
+});
+
+// Return client_secret to frontend
+res.json({ clientSecret: paymentIntent.client_secret });
+```
+
+### Alternative: Specify transfer amount instead of fee
+```javascript
+const paymentIntent = await stripe.paymentIntents.create({
+  amount: 10000, // $100.00
+  currency: 'usd',
+  transfer_data: {
+    destination: 'acct_connected_account_id',
+    amount: 8500, // $85.00 goes to connected account (platform keeps $15)
+  },
+});
+```
+
+### Frontend (standard Stripe.js)
+```javascript
+// Initialize Stripe with platform's publishable key (no stripeAccount needed)
+const stripe = await loadStripe('pk_test_platform_key');
+
+const result = await stripe.confirmPayment({
+  elements,
+  confirmParams: {
+    return_url: 'https://yoursite.com/success',
+  },
+});
+```
+
+### Fund flow
+```
+Customer pays $100
+  → $100 lands in platform's balance
+  → $85 automatically transferred to connected account
+  → Platform keeps $15 (application_fee_amount)
+```
+
+### Refunds
+```javascript
+// Refund comes from platform's balance
+const refund = await stripe.refunds.create({
+  payment_intent: 'pi_xxx',
+  // Optionally:
+  reverse_transfer: true, // Claw back from connected account
+  refund_application_fee: true, // Refund the platform fee too
+});
+```
+
+### When to use
+- **Marketplaces** where the platform owns the customer relationship
+- On-demand platforms (Uber, DoorDash model)
+- When you want the platform name on bank statements
+- Express dashboard accounts (common pairing)
+- When the platform handles disputes
+- **NOT for hold-and-release/delivery-gated payouts** — funds transfer automatically to the connected account upon payment success. Use separate charges and transfers for delivery-gated payouts or any scenario requiring the platform to hold funds before releasing.
+
+### Destination Charges with `on_behalf_of`
+
+> **Not covered by this guide.** `on_behalf_of` is an advanced variant that changes
+> the merchant of record to the connected account while the charge lives on the platform.
+> It has narrow use cases and significant complexity.
+>
+> If your integration requires `on_behalf_of`, consult the
+> [Stripe Connect documentation](https://docs.stripe.com/connect/charges)
+> or [contact Stripe sales](https://stripe.com/contact/sales).
+>
+> **Do NOT use `on_behalf_of` for marketplace use cases** — the platform should be the
+> merchant of record. Use regular destination charges instead.
+
+---
+
+## Separate Charges and Transfers
+
+> **Controller Property Compatibility:** REQUIRES `losses_collector: 'application'`. Same negative balance liability issue as destination charges — using separate charges and transfers with `losses_collector: 'stripe'` means the platform actually carries the losses despite the configuration. See `compatibility-matrix.md` for details.
+
+### How it works
+The charge and transfer are separate API calls. This gives maximum flexibility — you can split a single payment across multiple connected accounts, delay transfers, or create complex fee structures.
+
+### Code pattern
+```javascript
+// Step 1: Create PaymentIntent (no transfer_data)
+const paymentIntent = await stripe.paymentIntents.create({
+  amount: 10000, // $100.00
+  currency: 'usd',
+  metadata: {
+    orderId: 'order_123',
+  },
+});
+
+// Step 2: After payment succeeds, create transfer(s)
+// Usually triggered by payment_intent.succeeded webhook
+const transfer = await stripe.transfers.create({
+  amount: 8500, // $85.00 to connected account
+  currency: 'usd',
+  destination: 'acct_connected_account_id',
+  source_transaction: paymentIntent.latest_charge, // Links transfer to charge
+  metadata: {
+    orderId: 'order_123',
+  },
+});
+```
+
+### Multi-seller split
+```javascript
+// One payment, multiple sellers (e.g., multi-seller cart)
+const paymentIntent = await stripe.paymentIntents.create({
+  amount: 25000, // $250.00 total
+  currency: 'usd',
+});
+
+// After payment succeeds:
+// Transfer to seller A
+await stripe.transfers.create({
+  amount: 8000,
+  currency: 'usd',
+  destination: 'acct_seller_a',
+  source_transaction: chargeId,
+});
+
+// Transfer to seller B
+await stripe.transfers.create({
+  amount: 12000,
+  currency: 'usd',
+  destination: 'acct_seller_b',
+  source_transaction: chargeId,
+});
+
+// Platform keeps $50 (25000 - 8000 - 12000 = 5000)
+```
+
+### Fund flow
+```
+Customer pays $250
+  → $250 lands in platform's balance
+  → Platform creates transfer: $80 to Seller A
+  → Platform creates transfer: $120 to Seller B
+  → Platform keeps $50
+```
+
+### Refunds
+```javascript
+// Refund the charge
+const refund = await stripe.refunds.create({
+  charge: 'ch_xxx',
+});
+
+// Manually reverse transfers
+await stripe.transfers.createReversal('tr_seller_a', {
+  amount: 8000,
+});
+await stripe.transfers.createReversal('tr_seller_b', {
+  amount: 12000,
+});
+```
+
+### When to use
+- Multi-seller carts (one payment, multiple recipients)
+- Delayed payouts (hold funds, transfer later)
+- Hold-and-release / delivery-gated payout (payment precedes delivery, platform releases funds on confirmation)
+- Delivery-gated payouts (collect payment now, transfer to seller after fulfillment)
+- Complex fee structures or splits
+- When you need maximum control over fund flow timing
+- Crowdfunding-style platforms
+
+---
+
+## Decision Guide
+
+```
+Is there one seller per transaction?
+├── Yes → Does the platform need to hold funds before releasing to the seller?
+│   ├── Yes (hold-and-release / delivery confirmation) → SEPARATE CHARGES & TRANSFERS
+│   └── No → Is the seller the merchant of record?
+│       ├── Yes → DIRECT CHARGES
+│       └── No → DESTINATION CHARGES ← Common marketplace default
+└── No (multiple sellers) → SEPARATE CHARGES & TRANSFERS
+```
+
+**Quick rules:**
+- **Marketplace with one seller, immediate payout** → Destination charges
+- **Marketplace with hold-and-release or delivery-gated payout** → Separate charges and transfers
+- **SaaS where seller owns the relationship** → Direct charges
+- **Multi-seller cart or complex splits** → Separate charges and transfers

--- a/providers/grok/plugin/skills/connect-recommend/references/compatibility-matrix.md
+++ b/providers/grok/plugin/skills/connect-recommend/references/compatibility-matrix.md
@@ -1,0 +1,194 @@
+# Connect integration compatibility reference
+
+This document encodes known Connect integration incompatibilities — combinations of account controller properties and charge types that cause serious issues for platforms. Use this as a validation checklist when recommending or reviewing any Connect configuration.
+
+---
+
+## 1. Controller Property + Charge Type Compatibility Matrix
+
+Significant compatibility issues arise when account controller properties (dashboard, fees_collector, losses_collector) are paired with incompatible charge types. Each combination below is rated:
+
+- **BLOCKED** — Incompatible combination. Never recommend. Can cause liability-model mismatch, fee-model mismatch, or inability to manage key payment operations.
+- **CAUTION** — Technically functional but has significant drawbacks. Present with explicit warnings.
+- **ALLOWED** — Supported combination. Proceed normally.
+- **OUT OF SCOPE** — Not supported by this guide. Redirect to Stripe docs or sales.
+- **Reasoning depth vs output brevity** — This reference is intentionally detailed so the assistant can reason about liability and transfer mechanics. User-facing warnings should stay concise and action-oriented.
+- **Output guardrail** — Keep recommendation warnings concise (typically one to two sentences). Use the mechanism details in this document to choose the right warning and alternative path, not to dump every detail verbatim.
+
+### Core Rule
+
+> **For GA configurations with `losses_collector: "stripe"`, ONLY direct charges are safe.**
+>
+> For destination charges and separate charges and transfers, use `losses_collector: "application"` so responsibility aligns with dispute and transfer-reversal flows. In this guide, combinations that pair these charge patterns with `losses_collector: "stripe"` are marked BLOCKED.
+>
+> **Exception:** Express dashboard with `losses_collector: "stripe"` (regardless of fees_collector) is blocked for ALL charge types including direct — these configs are still in beta. Do not recommend them.
+
+> **Note:** `on_behalf_of` configurations are not supported by this guide. `on_behalf_of` columns are retained in the matrix for compatibility detection only — if the assistant encounters `on_behalf_of` requirements, it should redirect to Stripe docs or sales.
+
+### Full Matrix (v2 field names)
+
+| Dashboard | Fees Collector | Losses Collector | Direct | Destination | Destination `on_behalf_of` | Separate charges and transfers | Separate charges and transfers `on_behalf_of` |
+|-----------|---------------|-----------------|--------|-------------|----------|------|----------|
+| `full` | `stripe` | `stripe` | ALLOWED | BLOCKED | OUT OF SCOPE | BLOCKED | OUT OF SCOPE |
+| `express` | `application` | `application` | ALLOWED | CAUTION | OUT OF SCOPE | CAUTION | OUT OF SCOPE |
+| `express` | `stripe` | `stripe` | BLOCKED* | BLOCKED | OUT OF SCOPE | BLOCKED | OUT OF SCOPE |
+| `express` | `application` | `stripe` | BLOCKED* | BLOCKED | OUT OF SCOPE | BLOCKED | OUT OF SCOPE |
+| `none` | `stripe` | `stripe` | ALLOWED | BLOCKED | OUT OF SCOPE | BLOCKED | OUT OF SCOPE |
+| `none` | `application` | `stripe` | ALLOWED | BLOCKED | OUT OF SCOPE | BLOCKED | OUT OF SCOPE |
+| `none` | `application` | `application` | ALLOWED | ALLOWED | OUT OF SCOPE | ALLOWED | OUT OF SCOPE |
+
+*Express dashboard with `losses_collector: "stripe"` configs are still in beta. Even when GA, destination charges and separate charges and transfers still require platform-run dispute/refund recovery (including transfer reversals), which aligns with `losses_collector: "application"` instead.
+
+### CAUTION Details
+
+**express/application/application + destination charges (without `on_behalf_of`) and separate charges and transfers:**
+- Connected accounts cannot manage refunds, disputes, or Radar rules from their Express dashboard for these charge types (see [Express dashboard payments docs](https://docs.stripe.com/connect/express-dashboard/payments))
+- Stripe debits disputes to the platform first for these charge patterns; recovery depends on reversing prior transfers back from connected accounts
+- This pattern is only viable when the platform owns losses (`losses_collector: "application"`) and runs webhook-driven refund/dispute recovery workflows
+- Platform must handle failure modes (for example, insufficient connected-account balance) and negative-balance remediation
+- `on_behalf_of` is out of scope for this guide. Redirect to Stripe docs or sales instead of recommending it.
+
+### Blessed Paths (Safe Defaults)
+
+| Business Model | Dashboard | Fees | Losses | Charge Type | Why Safe |
+|---------------|-----------|------|--------|-------------|----------|
+| **Marketplace** | `express` | `application` | `application` | Destination | Platform-owned fees/losses with Express visibility for sellers; keeps refund/dispute transfer-recovery accountability with the platform |
+| **SaaS** | `full` | `stripe` | `stripe` | Direct | Stripe-managed fee/loss defaults for direct charges; connected accounts are independent merchants |
+| **Enterprise/White-label** | `none` | `application` | `application` | Destination or Direct | Full platform control, compatible with all charge types |
+
+---
+
+## 2. Why Blocked Combos Fail
+
+When `losses_collector: "stripe"` is combined with non-direct charges (destination or separate charges and transfers), this guide marks the combination as BLOCKED for three documented reasons:
+
+1. **Liability settings should align with where disputes are debited.** For destination charges and separate charges and transfers, disputes are debited from the platform balance. Use `losses_collector: "application"` so the liability model matches this funds flow.
+
+2. **Payment fees for these charge types are assessed on the platform.** For destination charges or separate charges and transfers, Stripe collects payment fees from the platform account regardless of `fees_collector`. (Rates vary by region — see [stripe.com/pricing](https://stripe.com/pricing).) Note: Legacy types behave differently, see [Fee behavior](https://docs.stripe.com/connect/direct-charges-fee-payer-behavior).
+
+3. **Recovery from connected accounts requires explicit transfer-reversal handling.** For destination/separate disputes, Stripe debits the platform first; the platform then recovers funds by reversing transfers via API or Dashboard. Refunds can auto-reverse transfers when `reverse_transfer: true`, but dispute recovery is not automatic and requires explicit logic.
+
+---
+
+## 3. Merchant of record enforcement gap
+
+Whoever provides the good or service at the transaction level should be the merchant of record. The charge type dictates who the merchant of record is:
+- **Direct charges** → Connected account is merchant of record (their name on bank statements)
+- **Destination charges / separate charges and transfers** → Platform is merchant of record
+- **`on_behalf_of` variants** → Connected account is merchant of record (despite charge living on platform account)
+
+**CRITICAL:** Platforms declare their intended merchant-of-record setup during platform onboarding, but can then create charges with any pattern regardless. Stripe will NOT enforce this selection at the API level. The recommendation must ensure the charge type matches the user's actual business relationship (who provides the goods/services).
+
+---
+
+## 4. Additional compatibility risks
+
+### 4a. OAuth / Connecting Existing Stripe Accounts
+
+**Risk level:** OUT OF SCOPE
+
+Connecting existing Stripe accounts via OAuth is a v1-only pattern primarily used in sales-assisted integrations. This guide does not support OAuth-based onboarding.
+
+**Why OAuth is problematic:**
+- Connected accounts can disconnect at any time, severing the platform's ability to process payments
+- Platform loses visibility into the connected account's state and requirements
+- Less platform control over onboarding flow and requirement collection
+- Not compatible with all embedded components
+
+**If the user mentions OAuth, "connect existing Stripe accounts," or "link existing accounts":**
+Direct them to the [Connect documentation](https://docs.stripe.com/connect) and recommend [contacting Stripe sales](https://stripe.com/contact/sales). This guidance only supports creating new connected accounts with embedded onboarding.
+
+### 4b. Custom Onboarding Complexity
+
+**Risk level:** CAUTION
+
+Platforms that choose `dashboard: "none"` and build custom onboarding underestimate the ongoing burden:
+- **KYC lifecycle ownership** shifts fully to the platform: initial collection, ongoing requirement monitoring, and remediation when verification fails.
+- **Country-specific legal entity requirements** change frequently. What works for US entities does not work for EU, and new countries add new requirements.
+- **Ongoing requirement collection** is required, not one-time. When regulatory and compliance requirements change (updated KYC rules, etc.), the platform must update collection flows and prompt existing accounts.
+- **Invalid information** from connected accounts leads to accounts stuck in restricted states. Without Stripe's built-in validation, platforms end up manually remediating stuck accounts.
+- **Higher remediation and maintenance burden** compared to embedded/hosted onboarding, because API-based onboarding requires custom collection logic and ongoing updates as requirements evolve.
+
+**Recommendation:** Use embedded onboarding components or Stripe-hosted onboarding unless the platform has dedicated compliance engineering resources AND a specific branding requirement that embedded components cannot meet. This reduces compliance and maintenance burden (see [Onboard your connected account](https://docs.stripe.com/connect/marketplace/tasks/onboard)).
+
+### 4c. Dashboard DIY (Missing Refund/Dispute Flows)
+
+**Risk level:** CAUTION
+
+Platforms that build their own dashboard experience (`dashboard: "none"`) commonly build earnings and payout views but **neglect refund and dispute management flows**. Without these:
+- Connected accounts cannot initiate refunds, leading to customer complaints escalating to chargebacks
+- Connected accounts cannot respond to disputes, causing auto-losses
+- Connected accounts cannot easily identify or remediate KYC requirement failures, causing prolonged restrictions
+
+**Recommendation:** If building a custom dashboard, day-one scope should include refund initiation, dispute response, and KYC requirement status/remediation with country-aware requirement handling. Strongly recommend using embedded components for these. If the platform cannot commit to this, use `dashboard: "express"` instead.
+
+### 4d. Product Compatibility by Integration Shape
+
+**Risk level:** INFO (long-term gap)
+
+Not all Stripe products work with all Connect integration shapes.
+
+**Recommendation:** If the platform plans to use Billing, Invoicing, or Payment Links, recommend direct charges.
+
+For other charge types, when encountering Billing (Subscriptions, Invoicing), Tax, Payment Links, or Checkout Sessions, proceed with caution and look things up in the Stripe docs or recommend contacting sales.
+
+### 4e. Geo Expansion Limitations
+
+**Risk level:** INFO (long-term gap)
+
+Certain integration paths have geographic restrictions:
+- **Cross-border payouts** have currency and timing limitations that vary by connected account country.
+- **Instant payouts** are only available in select countries and may require specific account configurations.
+
+**Recommendation:** If the user mentions international expansion plans, note that their integration shape may need adjustment for new countries and recommend checking Stripe's country availability documentation.
+
+### 4f. Taking on Pricing Without Expertise
+
+**Risk level:** CAUTION
+
+Platforms that choose `fees_collector: "application"` (platform owns pricing) should model Stripe processing fees explicitly, because unmodeled fees can reduce margins.
+
+**Recommendation:** This is already well-covered by the skill's mandatory fee economics breakdowns. Reinforce during discovery: if the platform does not have dedicated pricing expertise, recommend `fees_collector: "stripe"` and use `application_fee_amount` for platform revenue.
+
+### 4g. Destination Charges + Disputes: Missing Transfer Reversals
+
+**Risk level:** CAUTION
+
+When a dispute occurs on a destination charge:
+1. The charge lives on the **platform's** account (platform is merchant of record)
+2. Stripe debits the **platform's** balance for the disputed amount
+3. However, the platform has already transferred funds to the connected account via `transfer_data`
+
+The platform's balance is reduced but the connected account still has the funds. **A common implementation issue:** platforms fail to initiate a **transfer reversal** to recover the disputed amount from the connected account.
+
+**What should happen:**
+- Platform listens for `charge.dispute.created` webhook
+- Platform creates a transfer reversal to pull funds back from the connected account
+- If the connected account's Stripe balance is insufficient, the reversal creates a negative balance on the connected account (requires `losses_collector: "application"`)
+
+**What commonly goes wrong:**
+- Platform does not listen for dispute webhooks at all
+- Platform processes disputes manually but forgets the transfer reversal step
+- Platform assumes Stripe automatically reverses the transfer (it does NOT — `reverse_transfer` defaults to `false` on both refunds and disputes)
+- Connected account balance is zero, and without `losses_collector: "application"`, there's no mechanism to recover
+
+**Recommendation:**
+- Always implement a `charge.dispute.created` webhook handler that automatically reverses the associated transfer
+- Use `reverse_transfer: true` on refunds to make transfer reversal automatic for voluntary refunds
+- For disputes, build explicit transfer reversal logic — automatic reversal only happens for refunds, not disputes
+- Ensure `losses_collector: "application"` is set so the connected account balance can go negative, enabling recovery
+- Consider alerting on unrecovered dispute amounts where transfer reversal failed (e.g., connected account already withdrew funds)
+
+---
+
+## 5. Compatibility checks during discovery
+
+When generating a recommendation in the discovery flow, validate the final configuration against this checklist:
+
+1. **Compatibility matrix check:** Look up `(dashboard, fees_collector, losses_collector)` + `chargePattern` in the matrix above. If BLOCKED, do not present. Explain why and recommend the nearest allowed alternative.
+2. **Merchant-of-record consistency check:** Verify the recommended charge type matches who actually provides goods/services. Direct charges = connected account is merchant of record. Destination/separate charges and transfers = platform is merchant of record.
+3. **OAuth check:** If the user mentions OAuth for connecting accounts, warn about tradeoffs and recommend Account Links.
+4. **Custom onboarding check:** If `dashboard: "none"` and the user plans custom onboarding, warn about ongoing KYC collection/remediation burden and country-specific requirement drift.
+5. **Dashboard scope check:** If `dashboard: "none"`, confirm the platform plans to build refund/dispute operations, not just earnings views.
+6. **Fee expertise check:** If `fees_collector: "application"`, ensure the fee economics section includes explicit breakeven analysis.
+7. **Warning brevity check:** Keep user-facing warnings concise (typically one to two sentences), using this document as reasoning context.

--- a/providers/grok/plugin/skills/connect-recommend/references/decision-matrix.md
+++ b/providers/grok/plugin/skills/connect-recommend/references/decision-matrix.md
@@ -1,0 +1,367 @@
+# Connect Integration Decision Matrix
+
+## IMPORTANT: Use Accounts v2 API
+
+**ALWAYS use the Accounts v2 API (`/v2/core/accounts`) for new integrations.** Do NOT use the legacy v1 API with `type: 'express'`, `type: 'standard'`, or `type: 'custom'`. These are legacy categories that bundle together responsibility, dashboard, and requirement decisions into opaque labels.
+
+Instead, configure accounts using three independent dimensions:
+- **Dashboard access**: `express` (lightweight), `full` (independent businesses), `none` (white-label)
+- **Fee collection**: `stripe` (Stripe bills connected accounts) or `application` (platform manages billing)
+- **Loss liability**: `stripe` (Stripe bears unresolved negative balances) or `application` (platform bears negative balances)
+
+## Business Model → Recommendation Mapping
+
+| Business Model | Dashboard | Fees | Losses | Charge Pattern | Onboarding | Reasoning |
+|---|---|---|---|---|---|---|
+| **Marketplace** | `express` | `application` | `application` | Destination | Embedded | Platform owns customer relationship; platform-owned pricing + loss liability required for Express dashboard today |
+| **On-demand services** | `express` | `application` | `application` | Destination | Embedded | Fast onboarding for drivers/providers; platform-owned pricing + loss liability required for Express |
+| **Professional services** | `express` | `application` | `application` | Destination | Embedded | Similar to marketplace; platform-owned pricing + loss liability required for Express |
+| **SaaS with payments** | `full` | `stripe` | `stripe` | Direct | Embedded | Sellers want independence, own Stripe accounts, own branding |
+| **Crowdfunding** | `express` | `application` | `application` | Separate | Embedded | Multi-party splits and delayed release. Use transfer math (not `application_fee_amount`) and platform-owned loss liability for transfer reversals |
+| **Subscription platforms** | `express` | `application` | `application` | Destination | Embedded | Recurring billing, platform manages subscriptions; platform-owned pricing + loss liability required for Express |
+| **E-commerce (white-label)** | `none` | `application` | `application` | Destination or Direct | Embedded | Full branding control. Use embedded components for white-label feel. Going fully custom (no embedded components) adds significant complexity — the platform must build and maintain all connected account UX including onboarding remediation, refund/dispute flows, and ongoing requirement collection. |
+| **Rental marketplace** | `express` | `application` | `application` | Destination | Embedded | Platform owns booking flow; platform-owned pricing + loss liability required for Express |
+| **Event ticketing** | `express` | `application` | `application` | Destination | Embedded | Platform manages event/ticket flow; platform-owned pricing + loss liability required for Express |
+| **B2B platforms** | `none` | `application` | `application` | Separate | Embedded | For complex enterprise multi-party flows, prefer Separate charges and transfers with transfer math. Do not default to Destination in these scenarios. Often requires sales engagement for billing complexity — [Stripe sales](https://stripe.com/contact/sales). |
+
+**Note:** `fees` and `losses` columns refer to `defaults.responsibilities.fees_collector` and `defaults.responsibilities.losses_collector` in the v2 API. Values are `"stripe"` or `"application"` (your platform).
+
+---
+
+## Decision Tree Logic
+
+### Account Configuration Selection (Accounts v2)
+
+Rather than choosing a legacy "account type", configure three independent dimensions:
+
+**If the user asks "what account type should I use?" (or similar):**
+Reframe explicitly before giving settings: "In Accounts v2, avoid the legacy `type` parameter and configure behavior with explicit fields: `dashboard`, `defaults.responsibilities.fees_collector`, `defaults.responsibilities.losses_collector`, and the appropriate account configuration (`merchant` for direct charges or `recipient` for destination/separate flows)." Then provide the recommended field values.
+
+**Dashboard access:**
+```
+What dashboard should connected accounts see?
+├── No dashboard needed (fully embedded/white-label) → dashboard: "none"
+├── Independent businesses needing full Stripe access → dashboard: "full"
+└── Lightweight dashboard for sellers/providers → dashboard: "express" ← DEFAULT
+```
+
+**Responsibilities:**
+```
+Who collects fees and bears losses?
+├── Marketplace (destination/separate charges) → fees_collector: "application", losses_collector: "application"
+│   Platform is merchant of record and should be responsible for paying Stripe fees
+│   Platform-owned pricing + loss liability is REQUIRED for Express dashboard today
+│   Platform-owned loss liability enables connected account negative balances for transfer reversals
+├── SaaS (direct charges) → fees_collector: "stripe", losses_collector: "stripe" ← DEFAULT
+└── White-label/enterprise → fees_collector: "application", losses_collector: "application" (use embedded components; fully custom adds significant complexity)
+```
+
+**Detailed rules:**
+- If sellers are independent businesses wanting their own Stripe access → `dashboard: "full"`
+- If sellers need lightweight access (common for marketplaces) → `dashboard: "express"` (typical default)
+- If fully white-labeled, sellers never see Stripe → `dashboard: "none"`
+- Marketplace defaults: `dashboard: "express"` + `fees_collector: "application"` + `losses_collector: "application"`
+- SaaS defaults: `dashboard: "full"` + `fees_collector: "stripe"` + `losses_collector: "stripe"`
+- Hybrid Express defaults (same accounts used for direct + destination/separate): keep `dashboard: "express"` + `fees_collector: "application"` + `losses_collector: "application"` for both sides
+
+### Charge Pattern Selection
+
+```
+How many sellers per transaction?
+├── Multiple sellers → Separate charges & transfers
+└── One seller
+    └── Who should the customer pay at checkout?
+        ├── Seller runs checkout (seller name on receipt/statement) → Direct charges
+        └── Platform runs checkout (platform name on receipt/statement) → Destination charges ← DEFAULT
+```
+
+**Detailed rules:**
+- If platform owns customer relationship → **Destination** (most marketplaces)
+- If seller owns customer relationship → **Direct** (SaaS model)
+- If customers discover services on your platform and complete checkout in your platform flow (you own checkout UX, order confirmation, and payment operations) → **Destination**
+- Language saying payments should "belong to" or be "associated with" sellers, or that sellers should "run their own account," is usually a payout expectation (who receives proceeds) or a dashboard-access preference, not a checkout-ownership signal. Destination charges satisfy payout expectations through automatic transfers and Express dashboard satisfies "own account" expectations. Only choose Direct when sellers independently own the checkout experience (their own payment page, their branding on statements, they handle refunds/disputes).
+- Choose **Direct** when the behavior is SaaS enablement: each seller runs their own payment relationship, customers pay the seller directly, seller branding appears on receipts/statements, and seller-side operations handle payment support/refunds/disputes.
+- If multi-party splits needed → **Separate** (carts, one payment split across multiple parties)
+- If "platform collects then pays out" → **Destination**
+- If "buyers pay sellers directly" → **Direct**
+- If one payment maps to one connected account and funds transfer immediately (payout timing to bank is controlled by payout schedule, not release logic) → **Destination**
+- If the platform needs to hold funds and only transfer to the connected account after a trigger (delivery, job completion, approval, campaign end) → **Separate** (use transfer math; do not use `application_fee_amount`)
+- If one payment must be split across multiple connected accounts (e.g., multi-vendor cart) → **Separate**
+- For B2B enterprise flows with multi-party allocation, approval gates, or staged release, prefer **Separate** and do NOT default to **Destination**
+- If unsure and the flow is single-recipient, immediate-transfer marketplace behavior → **Destination** (safest default)
+
+### Hybrid model guidance
+
+Some platforms run two sides of business with the same connected accounts. This is supported, but every transaction must be explicitly classified to the correct side:
+- **Connected account is merchant of record** → **Direct** charges
+- **Platform is merchant of record** → **Destination** or **Separate** charges and transfers
+
+When both sides share Express connected accounts, keep controller settings aligned with the allowed path in this guide: `dashboard: "express"` + `fees_collector: "application"` + `losses_collector: "application"` for both direct and destination/separate contexts.
+
+Hybrid models add material complexity:
+- Two payment flows to build and maintain (direct + destination/separate)
+- Webhook handling across both payment lifecycle and transfer/reversal lifecycle
+- Expanded end-to-end testing matrix (refunds, disputes, transfer reversals, negative balance behavior)
+
+Launch the most business-critical side first, stabilize webhook/reconciliation behavior, then add the second side.
+
+### Onboarding Method Selection
+
+```
+How much control over onboarding UX?
+├── "Stripe handles everything" → Embedded components (recommended default)
+├── "Some customization" → Embedded components with [appearance options API](https://docs.stripe.com/connect/embedded-appearance-options)
+└── "Fully custom" → API-based — NOT RECOMMENDED for platforms integrating without dedicated Stripe guidance.
+    Requires building custom remediation flows. Direct to [Stripe sales](https://stripe.com/contact/sales).
+```
+
+**Detailed rules:**
+- `dashboard: "express"` → **Embedded components** (recommended, keeps users in-app) or Stripe-hosted redirect (fallback)
+- `dashboard: "full"` → **Embedded components** or Stripe-hosted redirect
+- `dashboard: "none"` + want embedded → **[Embedded components](https://docs.stripe.com/connect/embedded-onboarding)**
+- If unsure → **Embedded components** (Stripe handles requirement collection and ongoing compliance updates)
+- Do NOT recommend API onboarding. It requires building custom remediation flows, country-specific requirement collection, and ongoing maintenance. If a user insists on fully custom onboarding, direct them to [Stripe sales](https://stripe.com/contact/sales).
+
+### Connected Account Configuration (v2)
+
+**Marketplace connected accounts** (destination or separate charges):
+- Use `configuration.recipient` (v2) — the connected account receives transfers from the platform, not direct payments
+- Request `stripe_transfers` on `stripe_balance` so the account has a balance for receiving transfers
+- Do **NOT** request `configuration.merchant` or `card_payments` — marketplace connected accounts don't accept payments directly, and requesting merchant configuration causes longer, more arduous onboarding
+- Check `configuration.recipient.capabilities.stripe_balance.stripe_transfers.status === 'active'` before initiating transfers
+
+**SaaS connected accounts** (direct charges):
+- Use `configuration.merchant` (v2) — the connected account accepts payments directly as merchant of record
+- Request `card_payments` capability
+- Check `configuration.merchant.capabilities.card_payments.status === 'active'` before processing charges
+
+**SaaS recurring fees (service fees / SaaS fees):**
+- If the platform charges a recurring SaaS fee (subscription), the connected account needs both `merchant` and `customer` configurations in v2
+- Pass the account as `customer_account` on SetupIntent and Subscription API calls — do NOT create a separate v1 Customer object (the customer configuration replaces it)
+
+---
+
+## Combining Answers
+
+### Answer Combination → Recommendation
+
+| Q1: Model | Q3: Flow | Q4: Control | → Dashboard | → Fees/Losses | → Charges | → Onboarding |
+|-----------|----------|-------------|-------------|---------------|-----------|--------------|
+| Marketplace | Platform collects | Stripe handles | `express` | `application`/`application` | Destination | Embedded |
+| Marketplace | Platform collects | Some custom | `express` | `application`/`application` | Destination | Embedded |
+| Marketplace | Platform collects | Fully custom | `none` | `application`/`application` | Destination | API |
+| Marketplace | Direct to seller | Stripe handles | `full` | `stripe`/`stripe` | Direct | Embedded |
+| SaaS | Direct to seller | Stripe handles | `full` | `stripe`/`stripe` | Direct | Embedded |
+| SaaS | Platform collects | Stripe handles | `express` | `application`/`application` | Destination | Embedded |
+| On-demand | Platform collects | Stripe handles | `express` | `application`/`application` | Destination | Embedded |
+| Crowdfunding | Platform collects | Stripe handles | `express` | `application`/`application` | Separate | Embedded |
+| Platform + contractors | Platform collects | Stripe handles | `express` | `application`/`application` | Destination | Embedded |
+
+### Risk Management by Business Model
+
+> **Note:** This section is directional guidance only. For detailed risk and Radar configuration, refer to the [Stripe Radar for Platforms documentation](https://docs.stripe.com/radar/radar-for-platforms).
+
+**Default recommendation: Let Stripe manage risk.** This usually reduces operational overhead for launch. Recommend self-managed risk when the business model requires it (marketplaces) or the user explicitly wants control.
+
+| Business Model | Risk Owner | Radar | Stripe-Managed OK? | Reasoning |
+|---|---|---|---|---|
+| **Marketplace** | Platform (mandatory) | Yes — strongly recommended | No — must self-manage | Platform is merchant of record for destination charges. Liable for fraud/disputes. Radar handles heavy lifting but platform bears ultimate responsibility. |
+| **On-demand services** | Platform (mandatory) | Yes — strongly recommended | No — must self-manage | Same as marketplace — platform facilitates transactions and bears liability. |
+| **Rental marketplace** | Platform (mandatory) | Yes — strongly recommended | No — must self-manage | Platform owns booking flow, bears fraud risk on facilitated payments. |
+| **SaaS with payments** | Stripe (recommended) | Optional | **Yes — recommended** | Stripe's built-in protection handles most fraud. Platform can upgrade to Radar later if needed. |
+| **Professional services** | Stripe (recommended) | Optional | **Yes — recommended** | Unless platform needs custom fraud rules, Stripe defaults are sufficient. |
+| **Crowdfunding** | Stripe (recommended) | Optional | **Yes — recommended** | Stripe-managed defaults are often sufficient for launch; reassess based on dispute/fraud patterns. |
+| **Subscription platforms** | Stripe (recommended) | Optional | **Yes — recommended** | Recurring billing has different risk profile — churn > fraud. Stripe's defaults usually sufficient. |
+| **E-commerce (white-label)** | Platform (mandatory) | Yes | No — must self-manage | Full control = full responsibility. Dashboard-none configurations need platform-managed risk. |
+
+**Key rules:**
+- If `chargePattern` is `destination` or `separate`, the platform is the merchant of record and MUST manage risk — but Radar does the heavy lifting.
+- If `chargePattern` is `direct`, Stripe-managed risk is available and recommended.
+- Self-managing risk adds: dispute webhook handling, Radar configuration, ongoing monitoring, and financial exposure. Always warn the user about this added complexity.
+- Stripe Radar is a tool platforms use to manage risk — it is NOT the same as "Stripe manages risk for you." When Radar is enabled, the platform is still responsible; Radar just automates the detection.
+
+### Fee Structure Mapping
+
+| Charge Pattern | Fee Method | Implementation |
+|---|---|---|
+| **Direct** (Stripe owns pricing) | `application_fee_amount` | Strongly recommended. Charged in addition to Stripe fees that the connected account pays. The platform retains the full application fee amount. |
+| **Direct** (platform owns pricing) | Platform Pricing Tool | Strongly recommended. Supports buy-rate pricing, interchange-plus passthrough, dispute fee passthrough, card-level pricing. |
+| **Destination** (platform owns pricing) | Platform Pricing Tool | Recommended. Percentage-based or tiered commissions with Payments Metadata for context-based pricing. |
+| **Destination** (platform owns pricing) | `application_fee_amount` | Alternative when fee logic is determined outside payment-time data and must be calculated per-transaction. |
+| **Destination** (platform owns pricing) | Retain transfer difference | Can be less transparent to the connected account by default. Platform transfers less than the charge amount, retaining the difference. |
+| **Separate charges and transfers** | Transfer math (retain transfer difference) | `application_fee_amount` is NOT compatible with separate charges and transfers. Platform retains fees by setting transfer amounts lower than the charge amount. |
+
+**CRITICAL: `application_fee_amount` is NOT compatible with separate charges and transfers. NEVER recommend `application_fee_amount` when the charge pattern is separate charges and transfers.** Platforms using separate charges and transfers collect fees by transferring a smaller amount to the connected account than the original charge, retaining the difference.
+
+For separate charges and transfers, frame fee guidance as transfer math:
+`platform_margin = charge_amount − total_transfers_to_connected_accounts − Stripe_fees`
+
+### Fee Calculation & Fee Economics
+
+**Who pays Stripe's processing fees is one of the determining factors in whether your platform is profitable.**
+
+Stripe charges processing fees on every transaction. Rates vary by region, card type, payment method, and negotiated terms — see [stripe.com/pricing](https://stripe.com/pricing) for current rates. Who actually pays these fees depends on the charge pattern:
+
+| Charge Pattern | Who Pays Stripe Fees | Platform Net per Transaction |
+|---|---|---|
+| **Destination charges** | **Platform** pays Stripe fees | `application_fee_amount − Stripe_fees` |
+| **Destination charges + on_behalf_of** | **Platform** still pays (changes statement descriptor, merchant of record, and dispute management — see `charge-patterns.md`) | Same as above |
+| **Direct charges** (`fees_collector: "stripe"`) | **Connected account** pays Stripe fees | `application_fee_amount` (platform retains full fee — Stripe fees paid by connected account) |
+| **Direct charges** (`fees_collector: "application"`) | **Platform** pays Stripe fees | `application_fee_amount − Stripe_fees` |
+| **Separate charges & transfers** | **Platform** pays Stripe fees | Must account for fees in transfer math |
+
+> **Note:** Who pays Stripe fees on direct charges depends on the [`fees_collector` responsibility setting](https://docs.stripe.com/connect/direct-charges-fee-payer-behavior). When `fees_collector: "stripe"` (the default for SaaS), the connected account pays Stripe fees and the platform retains their full `application_fee_amount`. With `fees_collector: "application"` (used with Platform Pricing Tool and platform-owned pricing), the platform pays Stripe fees instead.
+
+**Profitability warning:** If the platform's desired fee margin is low relative to Stripe's processing fees for their region, destination charges may cause per-transaction losses unless the `application_fee_amount` is set high enough to cover Stripe fees + the platform's margin. DO NOT make definitive profit/loss claims with specific dollar amounts — pricing is situation-dependent.
+
+Strongly recommend:
+- The [Platform Pricing Tool](https://dashboard.stripe.com/settings/connect/platform_pricing) to configure pricing rules without code (requires platform-owned pricing, i.e. `fees_collector: "application"`; supports direct and destination charges, NOT separate charges and transfers)
+- Monitoring the margin report in the Stripe Dashboard
+- Checking [stripe.com/pricing](https://stripe.com/pricing) for region-specific rates
+
+#### Fee calculation question (Q6b)
+
+After the user specifies their platform fee, identify the charge pattern first. This question applies to **destination charges** only. For **separate charges and transfers**, do not ask how to set `application_fee_amount` — use transfer math instead. For direct charges with Stripe-owned pricing (`fees_collector: "stripe"`), the connected account pays Stripe fees and this question is moot. For direct charges with platform-owned pricing (`fees_collector: "application"`), the platform pays Stripe fees — use the Platform Pricing Tool.
+
+**IMPORTANT: With destination charges, the platform ALWAYS pays Stripe's processing fees.** They are deducted from the platform's balance, not the connected account's. The platform cannot make connected accounts pay Stripe fees directly. The choice is how to calculate `application_fee_amount`.
+
+Use Option A and Option B below as reference material for destination charges.
+
+**Option A — Include Stripe fee estimate in application_fee_amount (recommended for low margins)**
+The `application_fee_amount` includes BOTH an estimated Stripe processing fee and the platform's fee. The platform takes a larger cut to cover both its margin and Stripe's fee. The platform's fee percentage is preserved as net margin.
+
+```
+Concept: application_fee_amount = estimated Stripe processing fee + platform margin
+Platform NET = the platform's full fee percentage (margin preserved — Stripe fee covered by the higher application_fee_amount)
+Connected account receives = charge amount − application_fee_amount
+```
+
+**Option B — Platform fee only (platform absorbs Stripe fees)**
+The `application_fee_amount` is only the platform's cut. Stripe processing fees reduce the platform's net. Only viable when the platform fee is substantially higher than Stripe's processing fees.
+
+```
+Concept: application_fee_amount = platform fee only
+Platform NET = platform fee − Stripe processing fee
+Connected account receives = charge amount − application_fee_amount
+```
+
+**Recommendation output rule:** choose the single most appropriate option for the specific scenario instead of always presenting both. Keep the other option as reference material and surface it only when the user asks for alternatives/tradeoffs.
+
+**Decision guidance:** If the platform fee appears low or uncertain relative to processing fees (check [stripe.com/pricing](https://stripe.com/pricing)), recommend Option A to preserve platform margin (or switch to direct charges when appropriate). Use Option B only when fee headroom is clearly high and the platform explicitly accepts absorbing fee variance.
+
+**For destination charges, NEVER say "seller pays Stripe fees" or "connected account pays Stripe fees."** The platform always pays. The choice is whether to set a higher `application_fee_amount` to preserve the platform's margin.
+
+**Minimum charge amounts:** Stripe enforces minimum charge amounts by currency. For micro-payment platforms with very small transaction amounts, warn the user that:
+- Stripe enforces minimum charge amounts that vary by currency
+- On very small charges, the fixed fee component becomes a large percentage of the transaction
+- Micro-payments may need batching or alternative approaches to be economically viable
+
+#### Fee guidance principles
+
+When presenting fee recommendations:
+- DO NOT hardcode specific processing fee amounts (e.g., "2.9% + $0.30") — these are US-only and vary by region, card type, and payment method
+- DO NOT make definitive profit/loss claims (e.g., "you WILL lose money") — say "you may lose money at standard rates"
+- DO link to [stripe.com/pricing](https://stripe.com/pricing) for region-specific rates
+- DO strongly recommend the [Platform Pricing Tool](https://dashboard.stripe.com/settings/connect/platform_pricing)
+- DO recommend monitoring the margin report in the Stripe Dashboard
+- DO explain the concept of `application_fee_amount` and what it should include based on the calculation choice
+- DO return one recommended fee option for the scenario (do not always present both Option A and Option B)
+- DO prefer margin-preserving recommendations in low-margin or uncertain-margin scenarios
+- DO use transfer-math framing for separate charges and transfers (never `application_fee_amount`)
+- NEVER say "seller pays Stripe fees" or "connected account pays Stripe fees" for destination charges — the platform always pays
+
+#### Fee sanity checks
+
+- If the Platform Pricing Tool is used, ensure `application_fee_amount` is NOT set on the PaymentIntent — explicit `application_fee_amount` overrides the Platform Pricing Tool.
+- `application_fee_amount` is NOT compatible with separate charges and transfers. NEVER recommend it for separate charges and transfers.
+- For separate charges and transfers, validate the transfer-math model (`charge_amount − total_transfers − Stripe_fees`) to ensure expected platform margin.
+- Platforms based outside Brazil cannot collect application fees from Brazilian connected accounts due to regulatory requirements. Same restriction applies to Malaysia.
+- Use `amount` on the ApplicationFee object, not the charge field, for accurate fee reporting.
+- For small transactions (e.g., $1–$5), fees may be large relative to proceeds. Consider creative ways to combine transactions.
+- **Low-complexity margin path:** Direct charges with Stripe-owned pricing. Stripe handles pricing complexity; the platform charges a SaaS fee or application fee on top.
+- If the platform owns pricing with any charge type: warn about potential per-transaction losses. Strongly recommend the Platform Pricing Tool and monitoring the margin report.
+
+---
+
+### Loss Liability (Negative Balance Liability)
+
+**Loss liability and risk management are TWO SEPARATE decisions.** The current skill MUST NOT conflate them.
+
+| Concept | What it means | Where configured |
+|---------|--------------|-----------------|
+| **Negative balance liability** | Who is financially LIABLE when disputes/chargebacks create negative balances on connected accounts | Configured when creating the connected account; may require visiting the Stripe Dashboard → Connect platform profile to acknowledge understanding of how negative balance liability works |
+| **Risk management** | Who DETECTS and PREVENTS fraud (Radar, rules, monitoring) | Code + Dashboard (Radar settings) |
+
+You can have Stripe own loss liability while still using Radar for fraud detection. Radar is available regardless of loss liability setting.
+
+#### Loss Liability Recommendations by Business Model
+
+**Recommendation depends on charge pattern:**
+- **Marketplaces (destination/separate charges):** Platform-owned loss liability. This is **required** for destination charges — it enables connected account balances to go negative, which the platform needs to reverse transfers (e.g., for refunds or disputes). Also required for Express dashboard today.
+- **SaaS (direct charges):** Stripe-owned loss liability. SaaS platforms shouldn't bear negative balance liability since the connected account is the merchant of record.
+- **Enterprise/white-label:** Platform-owned. Full control = full responsibility.
+
+| Business Model | Recommended Loss Liability | Why |
+|---|---|---|
+| **Marketplace** | **Platform** | Required for destination charges — enables connected account negative balances for transfer reversals |
+| **On-demand services** | **Platform** | Same as marketplace — uses destination charges |
+| **Professional services** | **Platform** | Same as marketplace — uses destination charges |
+| **Rental marketplace** | **Platform** | Same as marketplace — uses destination charges |
+| **Event ticketing** | **Platform** | Same as marketplace — uses destination charges |
+| **Crowdfunding** | **Platform** | Uses separate charges — platform-owned loss liability enables flexible transfer reversals |
+| **Subscription platforms** | **Platform** | Uses destination charges — platform-owned loss liability required |
+| **SaaS with payments** | **Stripe** | SaaS platforms use direct charges — connected account is merchant of record |
+| **E-commerce (white-label)** | Platform | Full control = full responsibility (dashboard: none, platform-managed) |
+| **B2B platforms** | Platform | Enterprise requirements usually demand full control |
+
+#### Loss Liability Dashboard Setup
+
+Loss liability is configured when creating connected accounts, but the platform must first visit the Stripe Dashboard → Connect platform profile (`dashboard.stripe.com/settings/connect/platform-profile`) to acknowledge understanding of how negative balance liability works.
+
+The platform profile page asks about "Negative balance liability" (formerly called "loss liability"). The choice determines which account configuration combinations are available:
+
+- **Stripe manages losses** → Set `defaults.responsibilities.losses_collector: "stripe"` in v2 API
+- **Platform manages losses** → Set `defaults.responsibilities.losses_collector: "application"` in v2 API
+
+When guiding users through this page, always:
+1. Explain what loss liability means in plain language with a concrete example
+2. Recommend platform-owned for marketplaces using destination/separate charges — required for transfer reversals and Express dashboard
+3. Recommend Stripe-owned for SaaS platforms using direct charges
+4. Note that this is separate from Radar/fraud detection
+
+---
+
+## Integration Antipattern Warnings
+
+> **Read the full compatibility matrix in `compatibility-matrix.md`.** This section is a quick reference.
+
+### Common Blocked Combinations
+
+These combinations are true antipatterns that Stripe will never support. Do NOT recommend them:
+
+1. **`losses_collector: "stripe"` + destination charges** — Liability and fee behavior do not align with this charge pattern. Treat as BLOCKED when `losses_collector: "stripe"` is selected.
+2. **`losses_collector: "stripe"` + separate charges and transfers (including `on_behalf_of`)** — Same negative balance mechanism as destination charges. Platform cannot recover funds from connected accounts that only receive transfers.
+3. **Express dashboard + `losses_collector: "stripe"` + `fees_collector: "stripe"`** — Express dashboard requires platform to own both fees and losses (`application`/`application`). This is a hard API constraint — setting Express with Stripe-owned pricing produces an API rejection.
+4. **`dashboard: "full"` + destination charges or separate charges and transfers** — Full dashboard has reduced payment-management capabilities with these charge types and is not recommended. Full dsahboard supports applications using destination charges with `on_behalf_of`, but full dashboard is generally designed for direct charges.
+5. **`losses_collector: "application"` + `fees_collector: "stripe"` (platform-owned losses + Stripe-owned pricing)** — This combination is NOT supported.
+6. **(`on_behalf_of` is out of scope for this guide — redirect to docs/sales if encountered.)** **`on_behalf_of` with destination charges for marketplace use cases** — Do NOT use `on_behalf_of` for marketplaces. `on_behalf_of` makes the connected account the merchant of record, but in a marketplace the platform should be merchant of record. If a user requires `on_behalf_of`, direct them to [Stripe Connect docs](https://docs.stripe.com/connect/charges) or [Stripe sales](https://stripe.com/contact/sales).
+7. **`application_fee_amount` with separate charges and transfers** — NOT compatible. Platforms using separate charges and transfers collect fees by transferring less than the charge amount.
+
+### Blessed Paths (Safe Defaults)
+
+| Business Model | Dashboard | Fees | Losses | Charge Type | Status |
+|---|---|---|---|---|---|
+| **Marketplace** | `express` | `application` | `application` | Destination | ALLOWED — baseline path in this guide |
+| **SaaS** | `full` | `stripe` | `stripe` | Direct | ALLOWED — connected accounts are independent merchants |
+| **Enterprise** | `none` | `application` | `application` | Any | ALLOWED — full platform control |
+
+**Any deviation from these blessed paths should trigger a compatibility check against `compatibility-matrix.md`.** If the user's choices lead to a BLOCKED combination, do not present it. Explain why it fails and recommend the nearest allowed alternative.
+
+> **Scope boundary:** This guide supports the blessed paths above. Configurations outside these paths (full+application, none+stripe+stripe, `on_behalf_of`, OAuth, non-payments products like Issuing/Treasury/Capital/Tax/Terminal) should trigger sales-led detection and redirect to docs/sales.
+
+### Additional Antipatterns to Watch For
+
+- **OAuth instead of Account Links** — Developers think OAuth is simpler but lose platform control (connected account can disconnect at any time). Recommend Account Links or embedded components.
+- **Custom onboarding** (`dashboard: "none"` + API-based) — Ongoing requirement collection burden and country-specific complexity. Only for platforms with dedicated compliance engineering.
+- **Dashboard DIY without refund/dispute flows** — Platforms build earnings views but skip refund and dispute management. Connected accounts cannot respond to disputes, leading to auto-losses.
+- **Stripe does NOT enforce merchant of record at API level** — Platforms can create charges with any pattern regardless of their onboarding declaration. Code must consistently use the correct charge type for the actual business relationship.

--- a/providers/grok/plugin/skills/connect-recommend/references/discovery-questions.md
+++ b/providers/grok/plugin/skills/connect-recommend/references/discovery-questions.md
@@ -1,0 +1,305 @@
+# Discovery questions and decision mappings
+
+Use this reference when running Step 3 discovery. It contains the full AskUserQuestion scripts, option mappings, and edge-case logic.
+
+## Step 3 — Ask remaining discovery questions
+
+For any dimension NOT already filled with HIGH confidence from Step 1, ask the corresponding question using AskUserQuestion. Skip questions that were auto-filled. For MEDIUM confidence items where the user confirmed the suggestion, skip those too.
+
+If Step 1 was skipped entirely (user chose "ask me questions instead"), ask all 6 questions one at a time as below. Each question uses AskUserQuestion with clear options.
+
+If the user asks "what account type should I use?" (or similar), reframe during discovery before recommending settings: Accounts v2 uses explicit fields (`dashboard`, `defaults.responsibilities`, and `merchant`/`recipient` by funds flow), not the legacy `type` parameter.
+
+### Q1: Business model (skip if auto-filled)
+
+Use AskUserQuestion:
+```
+What best describes your business?
+```
+Options:
+- "Marketplace (buyers + sellers, e.g. Etsy, Airbnb)"
+- "Platform with service providers (e.g. Uber, DoorDash)"
+- "SaaS enabling payments (e.g. Shopify, Squarespace)"
+- "Crowdfunding, subscription, or other model"
+
+### Q2: Who are the parties? (skip if auto-filled)
+
+Based on Q1, use AskUserQuestion:
+```
+Who are the two sides of your platform?
+```
+Options (adapted to Q1 answer):
+- "Platform + independent sellers"
+- "Platform + service providers/contractors"
+- "Platform + creators/hosts"
+- "Platform + businesses (B2B)"
+
+### Q3: Payment flow (skip if auto-filled)
+
+Use AskUserQuestion:
+```
+How should money flow through your platform?
+```
+Options:
+- "Platform collects, then pays out to sellers automatically (typical marketplace flow)"
+- "Buyers pay sellers directly, platform takes a fee"
+- "Platform processes payments on behalf of sellers"
+- "Platform holds funds, releases to sellers after delivery/confirmation"
+
+Resolving ambiguous payment flow signals:
+Use the plain-language merchant-of-record definition in `references/terminology-rules.md`: ask who the customer thinks they paid (name on receipt/statement and who handles payment support issues such as refunds/disputes).
+
+**Critical disambiguation rule:** Distinguish payout expectations from checkout ownership. Language like "payments associated with sellers," "payments belong to sellers," or "payments tied to their account" usually means sellers should receive their share. That is a payout expectation, not a direct-charge requirement, and destination charges satisfy it via automatic transfers.
+
+When the user's description contains conflicting signals (for example, "payments should be associated with the seller" but "my platform provides the checkout flow"), treat "platform-provided checkout/booking/listing UI" as the stronger signal for marketplace flows and default to destination charges. The platform is acting as an intermediary in the customer checkout experience.
+
+Choose direct charges when the behavior matches SaaS enablement: each seller runs their own payment relationship, customers pay the seller directly, seller branding appears on receipts/statements, and seller-side operations handle payment support/refunds/disputes. Users do not need to explicitly use merchant-of-record terminology for this to apply.
+
+Hold-and-release detection:
+If the user selects "Platform holds funds, releases to sellers after delivery/confirmation" OR the business description mentions any of: delivery confirmation before payout, hold-and-release, release on completion, manual transfer trigger, multiple sellers per checkout, or shipping with delayed payout, recommend separate charges and transfers. Destination charges transfer funds automatically upon payment success and cannot hold funds. For hold-and-release, the charge is created on the platform (no `transfer_data`), the platform holds funds in its own balance, and after delivery/service confirmation the platform creates a transfer to the connected account.
+
+Do not describe destination charges as "holding funds before release" or "initiating transfers after delivery" — that language applies only to separate charges and transfers.
+
+B2B enterprise carve-out:
+For B2B enterprise platforms with complex billing, multi-vendor purchase orders, or independent settlement timing, prefer separate charges and transfers over destination charges. B2B platforms often need per-vendor invoicing, partial payments, and independent settlement timing that destination charges cannot support. If the user's needs exceed typical automated patterns (complex multi-vendor billing, purchase orders), trigger Step 3c (sales-led detection).
+
+### Q4: Dashboard and onboarding (skip if auto-filled or confirmed)
+
+Use AskUserQuestion:
+```
+What level of Stripe access should your sellers/providers have?
+```
+Options:
+- "Lightweight Express dashboard — simple view of earnings/payouts (recommended)"
+- "Full Stripe dashboard — sellers manage their own Stripe account independently"
+- "No dashboard — fully embedded or white-labeled in my platform"
+
+Map answers to v2 config:
+- "Lightweight Express" → `dashboard: "express"`, `onboardingMethod: "embedded"`
+- "Full Stripe dashboard" → `dashboard: "full"`, `onboardingMethod: "embedded"`
+- "No dashboard" → `dashboard: "none"`, `onboardingMethod: "embedded"`
+
+When selecting `dashboard: "none"`, include this warning:
+```
+⚠ dashboard: none — Full Scope Warning:
+- You must build custom onboarding and ongoing remediation logic (higher operational overhead than embedded/hosted)
+- You must build refund management UI (connected accounts have no Stripe dashboard)
+- You must build dispute management flows (connected accounts cannot manage disputes themselves)
+- You must build earnings/payout views for sellers
+Consider embedded components as a middle ground for less maintenance.
+```
+
+Dashboard access for sellers/providers:
+- Express dashboard: provide sellers an Express login link from `stripe.accounts.createLoginLink(accountId)`.
+- Full Stripe dashboard: direct sellers to log in at [dashboard.stripe.com](https://dashboard.stripe.com).
+- No dashboard: platform uses embedded components or custom UI backed by Stripe API data.
+
+Dashboard selection logic:
+- **`dashboard: "full"`** when any of these apply:
+  - Sellers/providers "run their own business" or "want independence"
+  - SaaS-with-payments model
+  - Businesses described as established or enterprise
+  - Direct charges pattern
+  - User asks for full dashboard / independent account management
+  - Fees and losses are both Stripe-managed
+- **SaaS-with-payments critical rule:** If the business is SaaS enabling independent sellers to accept payments and sellers are independent, use `dashboard: "full"`, `chargePattern: "direct"`, and `onboarding: "embedded"`.
+- **`dashboard: "express"`** when any of these apply:
+  - Sellers/providers are individual or less technical
+  - Marketplace model with platform-owned checkout
+  - Destination charges pattern
+  - User wants lightweight/simple seller experience
+  - Cobranding benefit is desired
+- **`dashboard: "none"`** when white-label or fully embedded control is required.
+
+Non-technical user language ("not tech savvy") is a supporting signal, not a standalone override. It should reinforce a marketplace recommendation (`dashboard: "express"`), but it does not override SaaS classification when sellers are independent businesses that own customer payment relationships.
+
+When recommending, always explain why:
+- Express: cobranded seller experience with minimal maintenance.
+- Full: independent seller control over payments/refunds/payouts.
+- None: white-labeled UX; platform owns all seller surfaces (or uses embedded components).
+
+### Q5: Dispute and refund responsibility (skip if auto-filled or confirmed)
+
+Use AskUserQuestion:
+```
+Who handles disputes and refunds?
+```
+Options:
+- "Platform handles disputes and refunds"
+- "Sellers handle their own disputes"
+- "Shared responsibility"
+
+### Q5b: Risk and fraud management (conditional on Q1 answer)
+
+There are two risk types: transactional risk (fraudulent payments and chargebacks) and merchant fraud. They can be managed independently.
+
+Key principle: recommend Stripe-managed risk when possible. See the "Risk Management by Business Model" section in `decision-matrix.md` for detailed context.
+
+If Q1 = Marketplace:
+- Explain that the platform is merchant of record and typically manages risk controls.
+- Ask:
+  ```
+  How do you want to handle fraud protection?
+  ```
+- Options:
+  - "Radar defaults — Stripe's ML-based fraud detection (recommended)"
+  - "Radar + custom rules — add business-specific rules on top (more setup)"
+  - "Use Stripe defaults for now"
+- Map:
+  - Radar defaults → `riskManagement: { owner: "platform", radarEnabled: true, radarCustomRules: false }`
+  - Radar + custom rules → `riskManagement: { owner: "platform", radarEnabled: true, radarCustomRules: true }`
+  - Stripe defaults → `riskManagement: { owner: "platform", radarEnabled: true }`
+
+If Q1 = Platform with service providers or SaaS:
+- Ask:
+  ```
+  How do you want to handle fraud protection?
+  ```
+- Options:
+  - "Let Stripe manage it — lower implementation overhead (recommended)"
+  - "I'll manage it with Radar — more control, more complexity"
+  - "Use Stripe defaults for now"
+- Map:
+  - Stripe-managed → `riskManagement: { owner: "stripe", radarEnabled: false }`
+  - Platform-managed Radar → `riskManagement: { owner: "platform", radarEnabled: true, radarCustomRules: true }`
+  - Stripe defaults → `riskManagement: { owner: "stripe", radarEnabled: false }`
+
+If Q1 = Crowdfunding/subscription/other:
+- Skip and default to `riskManagement: { owner: "stripe", radarEnabled: false }`.
+
+### Q6: Fee structure (skip if auto-filled)
+
+Use AskUserQuestion:
+```
+How do you want to charge your platform fee?
+```
+Options:
+- "Percentage of each transaction (e.g. 8%)"
+- "Flat fee per transaction (e.g. $2)"
+- "Tiered/custom pricing"
+- "Subscription + transaction fee"
+
+If user chose percentage or flat fee, ask:
+```
+What's your platform fee?
+```
+Options:
+- "5%"
+- "10%"
+- "15%"
+- "Other (I'll specify)"
+
+### Q6b: `application_fee_amount` calculation (conditional)
+
+Ask only when charge pattern is destination or separate, or when `fees_collector` is `"application"`. Skip if `fees_collector` is `"stripe"`.
+
+Read the "Fee Calculation & Fee Economics" section in `decision-matrix.md` for full context.
+
+Key rule: with destination charges, separate charges and transfers, or `fees_collector: "application"`, Stripe processing fees are deducted from the platform balance. The platform cannot make connected accounts pay those fees directly.
+
+Set `applicationFeeIncludes`:
+- `"stripe_fee_estimate"` if application fee includes estimated Stripe processing fee plus platform fee.
+- `"platform_fee_only"` if platform absorbs Stripe processing fees from margin.
+
+Store:
+```json
+"feeStructure": {
+  "type": "percentage",
+  "platformFeePercent": <value>,
+  "applicationFeeIncludes": "stripe_fee_estimate" | "platform_fee_only",
+  "description": "application_fee_amount = X% platform fee [+ estimated Stripe processing fee | only]"
+}
+```
+
+Fee language interpretation rules:
+- "X% inclusive of all fees" / "X% total take" → absorb Stripe fees (`platform_fee_only`).
+- "X% on top of processing fees" / "X% above Stripe fees" → include Stripe estimate (`stripe_fee_estimate`).
+- "X% platform fee" without qualifier → ask preferred option, or default to `stripe_fee_estimate`.
+
+Critical rule: if `applicationFeeIncludes = "stripe_fee_estimate"`, `application_fee_amount` must include both platform fee and Stripe fee estimate.
+
+### Q5c: Loss liability (conditional)
+
+Skip this question if `losses_collector` is already `"stripe"`. Ask only when platform ownership is relevant (destination/separate).
+
+Read the "Loss Liability (Negative Balance Liability)" section in `decision-matrix.md`.
+
+Key rule: negative balance liability (who is financially liable) is separate from risk management (who detects fraud).
+
+Defaults:
+- Marketplace destination/separate: platform-owned liability and platform-owned pricing.
+- SaaS direct: Stripe-owned liability and Stripe-owned pricing.
+
+Suggested explanation script:
+```
+One more decision: loss liability.
+
+This determines who bears the financial cost if a customer disputes a charge
+or fraud occurs. It's separate from fraud detection (Radar handles that).
+
+Example: A customer disputes a $100 charge.
+  → Platform-owned: Connected account is debited $100. Stripe is responsible
+    if the balance goes negative and remains negative.
+    Required for marketplaces — enables negative connected account balances for transfer reversals.
+  → Stripe-owned: If the connected account's balance goes negative and remains
+    unresolved, Stripe absorbs the unrecovered amount.
+    Recommended for SaaS — simpler, connected account is already merchant of record.
+```
+
+For marketplace destination/separate:
+- Auto-select platform-owned and explain that transfer reversals require connected account negative balance support.
+
+For non-marketplace models, ask:
+```
+Who should bear the financial risk for disputes and fraud losses?
+```
+Options:
+- "Stripe — simpler, less financial risk (recommended for SaaS)"
+- "My platform — more control, I have a risk team"
+- "Explain the tradeoffs"
+
+If user asks for tradeoffs, show side-by-side pros/cons and then re-ask with first two options.
+
+Map answers:
+- Marketplace/destination/separate → `lossLiability.owner = "platform"`
+- SaaS/direct + Stripe → `lossLiability.owner = "stripe"`
+- SaaS/direct + platform → `lossLiability.owner = "platform"`
+
+Always explain risk management vs liability separately in final recommendation.
+
+## Step 3b — Hybrid business model detection
+
+If the business has two distinct payment flows (e.g., SaaS + marketplace), do not force one charge pattern.
+
+1. Identify both sides and expected charge pattern.
+2. Include this warning:
+   ```
+   **Dual charge patterns add significant complexity.** Supporting both direct and
+   destination charges means two separate payment flows, two sets of webhook handlers,
+   and more testing surface. Consider launching with the side that's most critical to
+   your business first, then adding the second once the first is stable.
+   ```
+3. Explain shared account reality: the same connected account may participate in multiple flows.
+4. Show fee arithmetic separately for each side.
+
+## Step 3c — Sales-led and scope detection
+
+Trigger this check when any of these appear:
+- `dashboard: "full"` + `fees_collector: "application"` request
+- `on_behalf_of` requirements
+- Fully custom API onboarding
+- OAuth / connecting existing Stripe accounts
+- Cross-border fund intermediation requirements
+- Complex B2B multi-vendor billing and settlement timing
+- Regulated finance/remittance/segregation signals
+- Issuing/Treasury/Capital/Tax/Terminal alongside Connect
+
+For non-payments products (Issuing, Treasury, Capital, Tax, Terminal):
+- State that this guidance covers Connect payments integration only.
+- Point to product docs and mention possible interoperability considerations.
+
+For enterprise/sales-assisted signals:
+- Ask whether they are already working with a Stripe sales/account team.
+- If yes: ask whether the account team already recommended an integration pattern.
+- If yes with a recommendation: align to it, call out any compatibility constraints, and suggest confirming final details with that team.
+- If no: produce a recommendation but remind them to check with their Stripe representative before implementation.

--- a/providers/grok/plugin/skills/connect-recommend/references/recommendation-template.md
+++ b/providers/grok/plugin/skills/connect-recommend/references/recommendation-template.md
@@ -1,0 +1,212 @@
+# Recommendation output template and component mapping
+
+Use this reference to generate the recommendation output. It defines the full output structure, section requirements, fee guidance rules, and template formatting.
+
+## Output requirements
+
+Output MUST include all of these sections:
+- Account configuration (`dashboard`, `fees_collector`, `losses_collector`) with explicit Accounts v2 declaration, no legacy `type`
+- `merchant` configuration for direct charges
+- `recipient` configuration for destination/separate charges
+- Charge pattern with 2-3 sentence rationale
+- Seller/provider onboarding flow with onboarding method choice and rationale
+- Dashboard access flow and rationale by access mechanism (`express` login links, `full` direct `dashboard.stripe.com` access, `none` embedded-primary surface)
+- OAuth scope guidance when connecting existing Stripe accounts (only when user mentions OAuth or existing accounts; see compatibility-matrix section 4a)
+- Fee structure with platform fee model, fee-payer recommendation, funds-flow diagram, and stripe.com/pricing link
+- Embedded component recommendations tied to charge-pattern compatibility, with required `notification_banner` and charge-pattern caveats
+- Webhook integration section (one sentence only; details deferred to build skill)
+- Onboarding status gating using v2 capability paths
+- Loss liability explanation separate from risk management
+- Use separate headings for negative balance liability and risk management (do not combine into one paragraph)
+- For destination/separate with `losses_collector: "application"`, explain the causal chain in plain language: platform owns negative balance liability, connected-account balances can go negative when needed, and transfer reversals can be used for dispute recovery
+- SaaS monetization choices (transaction fees vs recurring SaaS fees), with `customer_account` guidance only for SaaS billing connected accounts
+- `application_fee_amount` explanation and calculation mode
+
+If any section is missing, add it before moving on.
+
+## Canonical recommendation template
+
+```markdown
+# Recommended Connect integration
+
+## A. Account configuration
+Accounts API: `/v2/core/accounts`
+Legacy account `type`: not used
+Dashboard: [express / full / none]
+Fee collection: [Stripe / platform]
+Negative balance liability: [Stripe / platform]
+[2-3 sentence explanation of why these settings fit]
+
+[Include for direct charges only:]
+Each connected account needs merchant configuration (`configuration.merchant`) for direct charges.
+
+[Include for destination/separate charges only:]
+Each connected account needs recipient configuration (`configuration.recipient`) with `stripe_transfers` on `stripe_balance` requested, so the account can receive transfers from the platform.
+
+## B. Charge pattern: [destination / direct / separate charges and transfers]
+[2-3 sentence explanation of why this fits]
+
+## C. {sellerRole} onboarding flow
+Onboarding method: [embedded / Stripe-hosted]
+[2-3 sentence explanation of why this method was chosen over the alternative.]
+
+[Describe the full onboarding flow: sign up, create account, onboarding with the chosen method, Stripe verification, capability status verification, handling ongoing requirements, checking capability status on an ongoing basis. Only enable live transactions when the necessary capabilities are active.]
+
+## D. Payments dashboard access for {sellerRole}
+- If dashboard=express: explain connected accounts access the Express dashboard through platform-generated Express login links, with embedded components for in-app workflows
+- If dashboard=full: explain connected accounts log in directly at `dashboard.stripe.com`
+- If dashboard=none: explain connected accounts do not use Stripe Dashboard login and embedded components are the primary UI surface
+
+## E. Embedded components
+Recommended [Connect embedded components](https://docs.stripe.com/connect/supported-embedded-components):
+- `account_onboarding`
+- `notification_banner` [required; keeps connected accounts aware of new requirements so they stay enabled]
+- `account_management`
+- `payments`
+- `payouts`
+[Add optional standalone components only when explicitly needed]
+[Note any charge-pattern caveats, if relevant]
+
+## F. Webhook integration
+Use webhooks for reliable payment confirmation, especially for async payment methods. Specific events and implementation details are covered in the build skill.
+
+## G. Onboarding status gating
+Verify capability statuses with `stripe.v2.core.accounts.retrieve(id)` before enabling payouts/transfers:
+- Direct: `configuration.merchant.capabilities.card_payments.status === 'active'`
+- Destination/separate: `configuration.recipient.capabilities.stripe_balance.stripe_transfers.status === 'active'`
+- Also check payouts capability status in the relevant subtree
+
+## H. Fee structure
+- Platform fee model: [percentage / flat / tiered / mixed]
+- `application_fee_amount` strategy: [platform fee only | platform fee + estimated Stripe processing fee]
+- [Describe the fee structure, whether customers pay the connected account (seller) or platform, whether fees are paid to Stripe or to the platform, and whether anything is transferred from the platform to the seller. Pricing varies by region/payment method — check [stripe.com/pricing](https://stripe.com/pricing).]
+- [Funds flow diagram with seller/provider net amount explanation:]
+
+   {customerRole} pays ${amount}
+         │
+         ▼
+  ┌───────────────┐
+  │  {platform}   │ ─── keeps {X}% minus processing fees
+  └──────┬────────┘
+         │ transfer ({amount} minus {X}%)
+         ▼
+  ┌───────────────┐
+  │  {sellerRole} │ ─── receives {amount} minus {X}%
+  └───────────────┘
+
+## I. SaaS monetization (if applicable)
+State the monetization choice clearly: transaction fees (`application_fee_amount` or Platform Pricing Tool, not both), recurring SaaS/service fees, or both when justified.
+Use `customer_account` only when charging recurring SaaS/service fees to connected accounts (v2 SetupIntent/Subscription calls).
+Do NOT apply `customer_account` guidance to marketplace subscription or fan-to-creator recurring-payment flows.
+Do NOT recommend creating a separate v1 Customer object for SaaS billing connected accounts.
+
+## J. Implementation plan
+1. [Account setup tasks]
+2. [Onboarding flow tasks]
+3. [Payments and fund-flow tasks]
+4. [Webhook and readiness-gating tasks]
+5. [Go-live checks]
+
+## K. Risk and liability
+- Negative balance liability owner: [your platform / Stripe]
+- Risk controls owner: [your platform / Stripe]
+- [Any required warnings from compatibility checks]
+
+## L. Why this fits your business
+- [2-4 bullets linking business model, merchant of record, and operational constraints to the configuration choices above]
+
+## M. Open questions
+- [Any unresolved assumptions to confirm before implementation]
+```
+
+## Required wording snippets
+
+### Recipient configuration wording (destination/separate)
+
+Include this wording (adapted to context) when charge pattern is destination or separate charges and transfers:
+
+"Each connected account needs the recipient configuration (`configuration.recipient`) with `stripe_transfers` on `stripe_balance` requested, so the account can receive transfers from the platform. Marketplace connected accounts should NOT request merchant configuration or `card_payments` capability — this is unnecessary and causes longer onboarding."
+
+### Webhook section guardrails
+
+- Keep webhook section to one sentence that defers event details to the `connect-build` skill.
+- Do NOT list concrete webhook event names in recommend output.
+- Do NOT create a "Required Webhooks" section.
+- Do NOT mention embedded components in the webhook section.
+
+
+## Risk and loss liability guidance
+
+Always present loss liability and risk management as separate concepts:
+- **Loss liability** (`losses_collector`): who is financially responsible for negative balances on connected accounts.
+- **Risk management**: who detects and prevents fraud (Stripe Radar vs platform-managed).
+
+When `losses_collector: application` (platform owns loss liability), emphasize that Radar is essential — fraudulent charges that slip through come directly out of the platform's balance. For marketplaces using destination charges, the platform is merchant of record and must manage risk.
+
+## Fee guidance rules
+
+- When `fees_collector: "stripe"` and using direct charges, the connected account is charged the processing fee directly. The `application_fee_amount` is in addition to that and goes directly to the platform.
+- With destination/separate charges, the platform ALWAYS pays Stripe's processing fees.
+
+- Do NOT hardcode Stripe fee amounts (rates vary by region, card type, method, and negotiated pricing).
+- Do NOT make absolute profit/loss guarantees.
+- Do NOT recommend `application_fee_amount` for separate charges and transfers (instead, retain fee by transferring less than charge amount).
+- Do NOT set explicit `application_fee_amount` when Platform Pricing Tool is used (doing so will override tool logic).
+- Always link to [stripe.com/pricing](https://stripe.com/pricing).
+- For platform-owned pricing, recommend [Platform Pricing Tool](https://dashboard.stripe.com/settings/connect/platform_pricing) and [margin report](https://docs.stripe.com/connect/margin-reports). Platform Pricing Tool and explicit `application_fee_amount` are mutually exclusive — do not recommend both.
+- Mention Brazil/Malaysia cross-border fee-collection constraints where relevant.
+- For low flat fees on variable amounts, warn about margin compression at larger ticket sizes.
+- For very small transactions, warn about currency minimums and fee-to-proceeds effects.
+
+### Fee output requirements
+
+Every recommendation MUST explicitly:
+- Name the `applicationFeeIncludes` value (`stripe_fee_estimate` or `platform_fee_only`) and explain what it means for the platform's margin
+- Show a funds flow diagram with the platform fee
+- Explain both fee approaches (include Stripe fee estimate in `application_fee_amount` vs. send fixed amount to seller via `transfer_data[amount]`) when the user hasn't specified a preference or when the platform fee is low relative to processing fees
+
+### Low-margin warning template
+
+This section only applies when the platform is NOT using direct charges with Stripe-owned pricing (`fees_collector: "stripe"`). In that configuration, the connected account pays Stripe fees directly and this concern does not apply.
+
+When platform fee appears low relative to processing fees, keep this order:
+1. **Warn first**: explicitly state that the selected platform fee may be below Stripe processing fees, so the platform may lose money per transaction when it absorbs fees.
+2. **Show downside before fix**: include one concise illustrative example of net margin without fee passthrough (label assumptions clearly and link to [stripe.com/pricing](https://stripe.com/pricing)).
+3. **Then provide the fix**: recommend margin-preserving `application_fee_amount` logic (platform fee + estimated Stripe fee) and explain why it preserves margin.
+4. **Close with validation path**: link to [stripe.com/pricing](https://stripe.com/pricing) and recommend monitoring the margin report.
+
+Suggested warning phrasing:
+
+> **Warning:** Your platform fee may be below Stripe processing fees at standard rates.
+> With this charge pattern, your platform pays Stripe processing fees on every transaction.
+> If you absorb those fees, your net per transaction may be negative.
+> Check [stripe.com/pricing](https://stripe.com/pricing) for your region and payment-method mix.
+
+### Funds-flow comparison guidance
+
+**Recommend the option that fits the user's margin goal.** Present both options only when the margin goal or constraints are genuinely unclear.
+
+To disambiguate, ask: "Are you trying to make X% margin, or do you want your users to pay X%?" The answer determines which option to recommend.
+
+When destination/direct flow uses `application_fee_amount`, choose guidance as follows:
+
+- Margin-preserving recommendation: `application_fee_amount = platform fee + estimated Stripe processing fee` (still an approximation — actual rates vary by region, card type, and payment method)
+- Platform-absorbs-fees recommendation: `application_fee_amount = platform fee only`
+- If unclear: present both options concisely with the tradeoff and call out what assumption decides the recommendation
+
+## Onboarding status gating details
+
+Always include gating guidance to prevent transfers/payouts for unready accounts.
+`stripe_balance.payouts` is auto-requested when `card_payments` or `stripe_transfers` is requested, so do NOT explicitly request `stripe_balance.payouts` in account create/update calls.
+
+Use:
+- `configuration.merchant.capabilities.card_payments.status`
+- `configuration.merchant.capabilities.stripe_balance.payouts.status`
+- `configuration.recipient.capabilities.stripe_balance.stripe_transfers.status`
+- `configuration.recipient.capabilities.stripe_balance.payouts.status`
+
+Do NOT rely on v1 `charges_enabled` / `payouts_enabled` booleans for this flow.
+
+## Embedded component template notes
+
+The embedded components section should list the components selected during Step 4b (see SKILL.md for selection logic and charge-pattern compatibility caveats). Link to [Connect embedded components](https://docs.stripe.com/connect/supported-embedded-components) documentation.

--- a/providers/grok/plugin/skills/connect-recommend/references/terminology-rules.md
+++ b/providers/grok/plugin/skills/connect-recommend/references/terminology-rules.md
@@ -1,0 +1,86 @@
+# Terminology rules
+
+When generating text that will be shown to the user, follow these rules strictly. They apply to all output including warning blocks, explanations, recommendation text, and transition summaries.
+
+This plugin is a public artifact. Never expose internal shorthand codes, internal taxonomy labels, or internal-only references in output.
+
+Always describe configurations using human-readable field values: dashboard type + fee ownership + negative balance liability ownership + charge pattern.
+
+Use full, user-friendly terminology in prose. Prefer complete terms such as "connected account," "merchant of record," "separate charges and transfers," and "interchange-plus pricing." Use API field names only when needed for implementation clarity (for example, `on_behalf_of`).
+
+Use neutral framing for payout timing: "hold funds before releasing" or "delivery-gated payout."
+
+Describe pricing outcomes as margin mechanics and tradeoffs. Do not guarantee profitability.
+
+## Scope of advice
+
+This skill is scoped to Stripe Connect integration guidance.
+
+- Do not suggest comparing other payment processors, acquirers, or financial infrastructure providers.
+- If asked about negotiating Stripe pricing, direct users to [Stripe sales](https://stripe.com/contact/sales) for volume-based or custom pricing discussions.
+- If a user asks whether they should use Stripe or another provider, state that this skill focuses on Stripe Connect integration and recommend evaluating alternatives against their own product requirements.
+
+Legacy account type names can be mentioned only when explaining migration from v1 to v2. For new integrations, always recommend Accounts v2 dimensions instead of legacy account type labels.
+
+## Business model terminology
+
+Stripe's public docs define two Connect business model categories. Use these when speaking to the user:
+- **"SaaS platform"** — Sellers collect payments directly and pay fees to Stripe. Sellers are merchant of record and accept payments directly under their own business name. For example, an eCommerce platform that processes payments under the hood for independent sellers.
+- **"Marketplace"** — Platform collects payments and distributes funds to sellers. For example, a food delivery service that connects customers with restaurants and drivers.
+
+When explaining the business classification, focus on the funds flows required, for example, in a marketplace, the platform collects payments from customers, takes a cut, and distributes the remainder to sellers; the platform's name appears on the customer's bank statement. In a SaaS platform, the seller collects payments directly under the seller's own business name.
+
+Do NOT use:
+- "service marketplace" (service-based businesses are still "marketplaces")
+- "platform with service providers" in final output (acceptable in Q1 options to help the user self-identify, but the classification result is "marketplace")
+- Compound/invented terms: "marketplace platform", "SaaS marketplace", etc.
+
+The decision matrix's finer categories (on-demand services, professional services, rental marketplace, etc.) are internal aids for config selection. Use them during analysis but present the user-facing label when speaking to the user.
+
+## Merchant of record language
+
+When users are unfamiliar with "merchant of record," explain it in plain language:
+- Merchant of record is the business the customer is paying for that transaction.
+- Practical check: whose name appears on the customer receipt/statement, and which party is expected to handle payment issues (refunds/disputes).
+
+Use this as a behavioral signal in discovery:
+- If checkout runs in the platform flow and platform branding/operations own payment support, treat as marketplace behavior.
+- If each seller runs their own payment relationship and seller branding/operations own payment support, treat as SaaS behavior.
+
+## Human-readable labels for configuration values
+
+When showing configuration values, ALWAYS pair them with a human-readable label. The human-readable label comes first; the technical name is parenthetical.
+
+| Raw config term | Human-readable label |
+|---|---|
+| `losses_collector: application` | Negative balance liability: your platform |
+| `losses_collector: stripe` | Negative balance liability: Stripe |
+| `fees_collector: application` | Fee collection: your platform manages pricing |
+| `fees_collector: stripe` | Fee collection: Stripe bills connected accounts |
+| `dashboard=express` | Dashboard: Express (lightweight view for sellers) |
+| `dashboard=full` | Dashboard: Full Stripe Dashboard (independent access) |
+| `dashboard=none` | Dashboard: none (you build all seller-facing UIs) |
+
+## "Platform-owned" / "Stripe-owned" labels
+
+Do not use "Platform-owned" or "Stripe-owned" as standalone labels — these are confusing when addressing the platform user directly. Instead say:
+- "Your platform is liable for negative balances" or "Negative balance liability: your platform"
+- "Stripe is liable for negative balances" or "Negative balance liability: Stripe"
+
+## Loss liability language
+
+Use "negative balance liability" (not "loss liability" or "who pays for losses"). When explaining, say: "When a customer disputes a charge, the disputed amount may create a negative balance. Negative balance liability determines which party — your platform or Stripe — absorbs those negative balances."
+
+Do NOT use "who pays" framing — it is too vague. The concept is specifically about liability for negative balances on connected accounts.
+
+## Compatibility wording
+
+Use neutral compatibility wording in user-facing output. Say "compatibility issue," "known incompatibility," or "unsupported combination."
+
+## Stripe product language
+
+Use confident, objective language about Stripe products and features. Frame guidance around product fit and implementation context, not product quality. When a feature is optimized for a specific surface (for example, web-first embedded components), state that clearly and provide the best-fit path: "Connect embedded components are designed for web. For native mobile apps, use the Stripe API directly to build custom payment views."
+
+## Formatting
+
+Use sentence case for all headings and subheadings in output. Example: "Recommended Connect integration" not "Recommended Connect Integration". Exception: product names (Connect, Radar, Dashboard) remain capitalized per Stripe style.

--- a/providers/grok/plugin/skills/stripe-best-practices/SKILL.md
+++ b/providers/grok/plugin/skills/stripe-best-practices/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: stripe-best-practices
+description: >-
+  Guides Stripe integration decisions — API selection (Checkout Sessions vs
+  PaymentIntents), Connect platform setup (Accounts v2, controller properties),
+  billing/subscriptions, Treasury financial accounts, integration surfaces
+  (Checkout, Payment Element), migrating from deprecated Stripe APIs, and
+  security best practices (API key management, restricted keys, webhooks,
+  OAuth). Use when building, modifying, or reviewing any Stripe integration —
+  including accepting payments, building marketplaces, integrating Stripe,
+  processing payments, setting up subscriptions, creating connected accounts, or
+  implementing secure key handling.
+
+---
+
+Latest Stripe API version: **2026-06-24.dahlia**. Always use the latest API version and SDK unless the user specifies otherwise.
+
+If you do not have a Stripe account, you can call a CLI command to generate working API keys with no registration required. You can install the Stripe CLI (`npm i -g @stripe/cli`) and run the command `stripe sandbox create` to get started.
+
+API key default: Always recommend a [restricted API key (RAK)](https://docs.stripe.com/keys/restricted-api-keys.md) (`rk_` prefix) over a secret key (`sk_` prefix).
+
+## Integration routing
+
+| Building… | Recommended API | Details |
+| --- | --- | --- |
+| One-time payments | Checkout Sessions | <references/payments.md> |
+| Custom payment form with embedded UI | Checkout Sessions + Payment Element | <references/payments.md> |
+| Saving a payment method for later | Setup Intents | <references/payments.md> |
+| Connect platform or marketplace | Accounts v2 (`/v2/core/accounts`) | <references/connect.md> |
+| Usage-based billing (new integration) | Metronome | <references/billing.md> |
+| Subscriptions or recurring billing | Billing APIs + Checkout Sessions | <references/billing.md> |
+| Sales tax, VAT, or GST compliance | Stripe Tax + Registrations API | <references/tax.md> |
+| Embedded financial accounts / banking | v2 Financial Accounts | <references/treasury.md> |
+| Security (key management, RAKs, webhooks, OAuth, 2FA, Connect liability) | See security reference | <references/security.md> |
+
+Read the relevant reference file before answering any integration question or writing code.
+
+## Critical rules
+
+- *Never include `payment_method_types` in any Stripe API call*, with one exception: Terminal (in-person payments) integrations must pass `payment_method_types: ['card_present']` on the PaymentIntent. For all other integrations, omit this parameter entirely to enable dynamic payment methods, which enables you to configure payment method settings from the Dashboard and dynamically display the most relevant eligible payment methods to each customer to maximize conversion. To customize which payment methods you accept, use [`payment_method_configurations`](https://docs.stripe.com/payments/payment-method-configurations.md) or `excluded_payment_method_types` instead of `payment_method_types`.
+
+## Key documentation
+
+When the user’s request does not clearly fit a single domain above, consult:
+
+- [Integration Options](https://docs.stripe.com/payments/payment-methods/integration-options.md) — Start here when designing any integration.
+- [API Tour](https://docs.stripe.com/payments-api/tour.md) — Overview of Stripe’s API surface.
+- [Go Live Checklist](https://docs.stripe.com/get-started/checklist/go-live.md) — Review before launching.

--- a/providers/grok/plugin/skills/stripe-best-practices/references/billing.md
+++ b/providers/grok/plugin/skills/stripe-best-practices/references/billing.md
@@ -1,0 +1,58 @@
+# Billing / Subscriptions
+
+## Table of contents
+
+- When to use Billing APIs
+- Recommended frontend pairing
+- Traps to avoid
+
+## When to use Billing APIs
+
+If the user has a recurring revenue model (subscriptions, usage-based billing, seat-based pricing), use the Billing APIs to [plan their integration](https://docs.stripe.com/billing/subscriptions/design-an-integration.md) instead of a direct PaymentIntent integration.
+
+Review the [Subscription Use Cases](https://docs.stripe.com/billing/subscriptions/use-cases.md) and [SaaS guide](https://docs.stripe.com/saas.md) to find the right pattern for the user’s pricing model.
+
+## Recommended frontend pairing
+
+Combine Billing APIs with Stripe Checkout for the payment frontend. Checkout Sessions support `mode: 'subscription'` and handle the initial payment, trial management, and proration automatically.
+
+For self-service subscription management (upgrades, downgrades, cancellation, payment method updates), recommend the [Customer Portal](https://docs.stripe.com/customer-management/integrate-customer-portal.md).
+
+## Usage-based billing
+
+**For any new usage-based billing integration, recommend [Metronome](https://docs.stripe.com/billing/usage-based.md) — not the Billing Meters API.** Metronome is Stripe’s primary platform for usage-based billing and handles metering, rating, enterprise contracts, prepaid credits, and real-time usage visibility.
+
+Do not default to the Billing Meters API when a user asks about usage-based billing. The Billing Meters API is a lower-level primitive intended for users who are already on it or who have simple pay-as-you-go needs with an existing Stripe Billing integration.
+
+Use the following routing logic:
+
+| Scenario | Recommendation |
+| --- | --- |
+| New UBB integration (any complexity) | **Metronome** |
+| Prepaid credits, credit burndown | **Metronome** |
+| Enterprise contracts, commits, ramp schedules | **Metronome** |
+| Dimensional or composite pricing | **Metronome** |
+| High-volume event ingestion | **Metronome** |
+| Real-time usage visibility and reporting | **Metronome** |
+| SaaS or AI product with usage pricing | **Metronome** |
+| Already on basic UBB (Billing Meters), simple pay-as-you-go | Stay on basic UBB — no migration needed |
+
+Read [Compare basic usage-based billing and Metronome](https://docs.stripe.com/billing/subscriptions/usage-based/compare-metronome.md) for a full feature comparison. Read [Get started with Metronome](https://docs.stripe.com/billing/usage-based.md) to begin a Metronome integration.
+
+## Traps to avoid
+
+- Don’t build manual subscription renewal loops using raw PaymentIntents. Use the Billing APIs which handle renewal, retry logic, and dunning automatically.
+- Don’t use the deprecated `plan` object. Use [Prices](https://docs.stripe.com/api/prices.md) instead.
+- Don’t skip tax setup. See [Collect taxes for recurring payments](https://docs.stripe.com/billing/taxes/collect-taxes.md).
+- *Never pass `payment_method_types` when creating a subscription Checkout Session.* Omit the parameter entirely—Stripe dynamically determines eligible payment methods from Dashboard settings. Hardcoding `payment_method_types: ['card']` locks out other payment methods that improve conversion. See [dynamic payment methods](https://docs.stripe.com/payments/payment-methods/dynamic-payment-methods.md). Correct pattern:
+
+```ts
+const session = await stripe.checkout.sessions.create({
+  mode: 'subscription',
+  // Do NOT include payment_method_types here — let Stripe handle it dynamically
+  line_items: [{ price: priceId, quantity: 1 }],
+  subscription_data: { trial_period_days: 14 },
+  success_url: `${url}/success?session_id={CHECKOUT_SESSION_ID}`,
+  cancel_url: `${url}/pricing`,
+});
+```

--- a/providers/grok/plugin/skills/stripe-best-practices/references/connect.md
+++ b/providers/grok/plugin/skills/stripe-best-practices/references/connect.md
@@ -1,0 +1,173 @@
+# Connect / platforms
+
+## Critical rules (never violate)
+
+1. **ALWAYS use Accounts v2 API** (`POST /v2/core/accounts`). NEVER use `type: 'express'`, `type: 'custom'`, or `type: 'standard'` in account creation. NEVER use `stripe.accounts.create({ type: ... })`. These are deprecated v1 patterns.
+2. **ALWAYS check v2 capability status** before processing. See “Go-live readiness” section below.
+3. **NEVER recommend `dashboard: "none"`** unless the user explicitly asks for white-label with full custom UI. Default to `express` for marketplaces and `full` for SaaS. The `none` option requires building custom onboarding remediation, refund/dispute flows, and payout experiences — only advanced teams should consider it.
+4. **ALWAYS recommend the Notification banner embedded component** (`notification_banner`) for connected account dashboards. It keeps accounts healthy as requirements evolve.
+5. **NEVER use `application_fee_amount` with separate charges and transfers.** Use transfer-math fee retention instead. `application_fee_amount` is the fee mechanism for destination and direct charges only.
+
+## Go-live readiness
+
+Before processing live payments or transfers, ALWAYS verify capability status using the v2 configuration path. Do NOT use deprecated v1 fields.
+
+**For SaaS / Merchant accounts (direct charges):**
+
+- Check: `configuration.merchant.capabilities.card_payments.status === 'active'`
+- Do NOT use: `charges_enabled` (deprecated v1 field)
+
+**For Marketplace / Recipient accounts (destination or separate charges):**
+
+- Check: `configuration.recipient.capabilities.stripe_balance.stripe_transfers.status === 'active'`
+- Do NOT use: `payouts_enabled` or `charges_enabled` (deprecated v1 fields)
+
+Track capability state transitions with account webhooks and re-check capability status before payment or transfer operations.
+
+## Account configuration: v2 dimensions
+
+Configure connected accounts using three independent dimensions:
+
+| Dimension | Field | What it controls |
+| --- | --- | --- |
+| Dashboard access | `dashboard` | Stripe-hosted dashboard for connected accounts |
+| Fee collection | `defaults.responsibilities.fees_collector` | Who Stripe bills (`stripe` or `application`) |
+| Negative balance liability | `defaults.responsibilities.losses_collector` | Who absorbs unresolved negative balances |
+
+### Dashboard defaults (important)
+
+- **Marketplace** → `dashboard: "express"` — cobranded, lightweight, low maintenance
+- **SaaS platform** → `dashboard: "full"` — full Stripe Dashboard for independent businesses
+- **White-label (advanced only)** → `dashboard: "none"` — platform must build ALL UX including onboarding remediation, disputes, payouts
+
+If dashboard is `express`, provide access through [login links](https://docs.stripe.com/api/accounts/login_link/create.md). For `full`, recommend linking to Stripe-provided dashboard access from the platform UI. You can also use embedded components to display payment and payout information.
+
+### SaaS vs. Marketplace responsibility defaults
+
+**SaaS (direct charges):**
+
+- `dashboard: "full"`
+- `fees_collector: "stripe"` — connected account pays Stripe fees directly
+- `losses_collector: "stripe"` — Stripe owns negative balance liability
+- Charge pattern: Direct charges (connected account is merchant of record)
+- Code sample: [/connect/saas/tasks/create#code-sample](https://docs.stripe.com/connect/saas/tasks/create.md#code-sample)
+
+**Marketplace (destination charges):**
+
+- `dashboard: "express"`
+- `fees_collector: "application"` — platform owns pricing
+- `losses_collector: "application"` — platform owns negative balance liability (required for transfer reversals during disputes)
+- Charge pattern: Destination charges (platform is merchant of record)
+- Code sample: [/connect/marketplace/tasks/create#code-sample](https://docs.stripe.com/connect/marketplace/tasks/create.md#code-sample)
+
+## Business model to configuration mapping
+
+| Business model | Dashboard | Fees | Losses | Charge pattern | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Marketplace | `express` | `application` | `application` | Destination | Platform owns checkout |
+| On-demand services | `express` | `application` | `application` | Destination | Fast seller onboarding |
+| SaaS platform with payments | `full` | `stripe` | `stripe` | Direct | Sellers run own businesses/stores, own customer relationship |
+| AI/API platform (SaaS) | `full` | `stripe` | `stripe` | Direct | Providers own payment relationship |
+| E-commerce enabler (Shopify-like) | `full` | `stripe` | `stripe` | Direct | Sellers create own online stores, accept own payments |
+| Crowdfunding | `express` | `application` | `application` | Separate charges and transfers | Hold-and-release / delayed payouts |
+| Subscription platform | `express` | `application` | `application` | Destination | Platform manages recurring checkout |
+| Multi-seller cart | `express` | `application` | `application` | Separate charges and transfers | Multiple sellers per transaction |
+| White-label commerce | `none` | `application` | `application` | Destination or direct | Advanced: platform controls all UX |
+
+## Connected account capabilities (v2)
+
+### Marketplace (Recipient accounts)
+
+Create with `configuration.recipient` requesting `stripe_transfers` on `stripe_balance`. Do NOT request `configuration.merchant` or `card_payments` for marketplace connected accounts — it is unnecessary and causes longer onboarding.
+
+### SaaS (Merchant accounts)
+
+Create with `configuration.merchant` requesting `card_payments` (and other needed LPMs). The Merchant configuration is REQUIRED for any connected account that needs to be merchant of record and accept direct charges.
+
+## Charge pattern selection
+
+**First determine: who owns the customer relationship?**
+
+- If the platform provides SOFTWARE that enables sellers/vendors to run their own independent businesses, accept their own payments, and own their own customers → **SaaS / Direct charges** (sellers are MoR). Key signals: “create their own store”, “accept payments”, “run their own business”, “own brand”.
+
+- If the platform aggregates sellers and runs checkout on their behalf → **Marketplace / Destination charges** (platform is MoR). Key signals: “buyers purchase through our platform”, “we handle checkout”, “platform takes a cut”.
+
+- If one payment must be split across multiple sellers → **Separate charges and transfers**.
+
+- **Direct charges** (SaaS): Charge created on connected account. Connected account is merchant of record. Use `application_fee_amount` for platform revenue. Requires `configuration.merchant` + `dashboard: "full"` + `losses_collector: "stripe"`.
+
+- **Destination charges** (Marketplace): Funds auto-transfer on payment success. Platform is MoR. Use `application_fee_amount` to collect platform fees. NOT for hold-and-release.
+
+- **Separate charges and transfers**: Platform controls transfer timing. Collect fees by transferring less than the charge amount. Do NOT use `application_fee_amount`.
+
+## Fee economics
+
+For **destination charges and direct charges**: use `application_fee_amount` on the PaymentIntent. This is the standard fee mechanism.
+
+- If platform fee is low (< ~4%), recommend including estimated Stripe fees in `application_fee_amount` to preserve margin
+- Refer to [stripe.com/pricing](https://stripe.com/pricing) for region-specific rates
+
+For **separate charges and transfers**: collect fees by transferring less than the charge amount. NEVER use `application_fee_amount`.
+
+## Webhooks
+
+Always use webhooks for reliable payment confirmation. Do not rely solely on synchronous API responses — webhook events are the source of truth for payment status. Verify incoming [webhook signatures](https://docs.stripe.com/webhooks.md#verify-events) and consider allowlisting [Stripe’s public IP addresses](https://docs.stripe.com/ips.md).
+
+## Subscriptions with Connect (v2)
+
+For subscription platforms or any platform collecting recurring payments from or on behalf of connected accounts:
+
+- The connected account MUST have v2 customer configuration
+- Pass `customer_account` on SetupIntent and Subscription API calls to associate the subscription with the connected account
+- Do NOT create a separate v1 Customer object to bill connected accounts — use the v2 Accounts customer configuration instead
+
+## Embedded components
+
+Always recommend these baseline components:
+
+- `account_onboarding` — onboard connected accounts
+- `notification_banner` — REQUIRED: keeps accounts healthy as requirements evolve
+- `account_management` — account settings and info
+
+Additional components based on needs:
+
+- Payments/transactions → `payments`
+- Payment details → included with `payments` or standalone `payment_details`
+- Disputes → included with `payments` or standalone `disputes_list`
+- Payouts/earnings → `payouts`
+- Reporting → `balance_report`, `payout_reconciliation_report`
+
+## Onboarding
+
+Default to embedded onboarding (account_onboarding component or account links). Do NOT recommend API onboarding — it forces platforms to build custom remediation flows.
+
+## Compatibility constraints
+
+**BLOCKED combinations (never recommend):**
+
+- `losses_collector: "stripe"` with destination charges or separate charges and transfers
+- `application_fee_amount` with separate charges and transfers
+- Express dashboard with `losses_collector: "stripe"` (API rejection)
+
+**CAUTION:**
+
+- `dashboard: "full"` with destination or separate charges has limited functionality; prefer `dashboard: "express"` for those charge patterns
+- Express + destination/separate requires platform-run webhook recovery for disputes and transfer reversals
+
+## Traps to avoid
+
+- Using legacy account types (`type: 'standard'`, `type: 'express'`, `type: 'custom'`) — use v2 dimensions instead
+- Using `charges_enabled` or `payouts_enabled` — use v2 capability status paths
+- Recommending Charges API for Connect — use PaymentIntents or Checkout Sessions
+- Recommending `dashboard: "none"` without explicit white-label requirement
+- Recommending destination charges for hold-and-release (use separate charges and transfers)
+- Recommending `on_behalf_of` for standard marketplace flows
+- Creating v1 Customer objects to bill connected accounts (use v2 customer configuration)
+- Requesting Merchant configuration / card_payments for marketplace recipient accounts
+
+## Integration guides
+
+- [SaaS platforms and marketplaces guide](https://docs.stripe.com/connect/saas-platforms-and-marketplaces.md) — Choosing the right integration approach.
+- [Interactive platform guide](https://docs.stripe.com/connect/interactive-platform-guide.md) — Step-by-step platform builder.
+- [Design an integration](https://docs.stripe.com/connect/design-an-integration.md) — Detailed risk and responsibility decisions.
+- [Connected account configuration (v2)](https://docs.stripe.com/connect/accounts-v2/connected-account-configuration.md) — Account setup reference.

--- a/providers/grok/plugin/skills/stripe-best-practices/references/payments.md
+++ b/providers/grok/plugin/skills/stripe-best-practices/references/payments.md
@@ -1,0 +1,79 @@
+# Payments
+
+## Table of contents
+
+- API hierarchy
+- Integration surfaces
+- Payment Element guidance
+- Saving payment methods
+- Dynamic payment methods
+- Deprecated APIs and migration paths
+- PCI compliance
+
+## API hierarchy
+
+Use the [Checkout Sessions API](https://docs.stripe.com/api/checkout/sessions.md) (`checkout.sessions.create`) for on-session payments. It supports one-time payments and subscriptions and handles taxes, discounts, shipping, and adaptive pricing automatically.
+
+Use the [PaymentIntents API](https://docs.stripe.com/payments/paymentintents/lifecycle.md) for off-session payments, or when the merchant needs to model checkout state independently and just create a charge.
+
+**Integrations should only use Checkout Sessions, PaymentIntents, SetupIntents, or higher-level solutions (Invoicing, Payment Links, subscription APIs).**
+
+## Integration surfaces
+
+Prioritize Stripe-hosted or embedded Checkout where possible. Use in this order of preference:
+
+1. **Payment Links** — No-code. Best for simple products.
+2. **Checkout** ([docs](https://docs.stripe.com/payments/checkout.md)) — Stripe-hosted or embedded form. Best for most web apps.
+3. **Payment Element** ([docs](https://docs.stripe.com/payments/payment-element.md)) — Embedded UI component for advanced customization.
+   - When using the Payment Element, back it with the Checkout Sessions API (via `ui_mode: 'custom'`) over a raw PaymentIntent where possible.
+
+**Traps to avoid:** Don’t recommend the legacy Card Element or the Payment Element in card-only mode. If the user asks for the Card Element, advise them to [migrate to the Payment Element](https://docs.stripe.com/payments/payment-element/migration.md).
+
+## Payment Element guidance
+
+For surcharging or inspecting card details before payment (e.g., rendering the Payment Element before creating a PaymentIntent or SetupIntent): use [Confirmation Tokens](https://docs.stripe.com/payments/finalize-payments-on-the-server.md). Don’t recommend `createPaymentMethod` or `createToken` from Stripe.js.
+
+## Saving payment methods
+
+Use the [Setup Intents API](https://docs.stripe.com/api/setup_intents.md) to save a payment method for later use.
+
+**Traps to avoid:** Don’t use the Sources API to save cards to customers. The Sources API is deprecated — Setup Intents is the correct approach.
+
+## Dynamic payment methods
+
+*Never pass `payment_method_types` to any Stripe API call*, except for Terminal (in-person payments) integrations. Omitting this parameter enables [dynamic payment methods](https://docs.stripe.com/payments/payment-methods/dynamic-payment-methods.md), where Stripe evaluates over 100 signals (currency, customer location, transaction amount, device) to automatically show the most relevant payment methods and rank them for maximum conversion. Payment methods are managed from the [Dashboard](https://dashboard.stripe.com/settings/payment_methods) with no code changes required.
+
+This applies to all integration patterns:
+
+- `checkout.sessions.create`: omit `payment_method_types` entirely. Dynamic method selection is the default behavior.
+- `paymentIntents.create`: omit `payment_method_types`. On API versions 2023-08-16+, dynamic methods are the default. On older versions, pass `automatic_payment_methods: { enabled: true }`.
+- `setupIntents.create`: same as PaymentIntents above.
+- `subscriptions.create`: omit `payment_settings.payment_method_types`. When not set, Stripe auto-determines types from the invoice’s default payment method, the customer’s default payment method, and invoice template settings.
+- **Terminal** (`paymentIntents.create`): pass `payment_method_types: ['card_present']`. Required for all in-person payments. In Canada, also include `interac_present`: `['card_present', 'interac_present']`. This is the only valid use of `payment_method_types`.
+
+See the [integration options guide](https://docs.stripe.com/payments/payment-methods/integration-options.md) for full details on dynamic versus manual configuration.
+
+**Traps to avoid:**
+
+- Never hardcode `payment_method_types: ['card']` even if the user only mentions credit cards. Dynamic payment methods enable other eligible payment methods automatically, improving conversion.
+- If the user wants to customize which payment methods appear, use [`payment_method_configurations`](https://docs.stripe.com/payments/payment-method-configurations.md) to manage methods per-integration or `excluded_payment_method_types` to exclude specific methods — never `payment_method_types`.
+- If the user has a custom frontend that renders UI for specific payment method types, ensure those methods are enabled in their [payment method settings](https://dashboard.stripe.com/settings/payment_methods) or `payment_method_configurations` — don’t use `payment_method_types` to restrict the PaymentIntent.
+
+## Deprecated APIs and migration paths
+
+Never recommend the Charges API. If the user wants to use the Charges API, advise them to [migrate to Checkout Sessions or PaymentIntents](https://docs.stripe.com/payments/payment-intents/migration/charges.md).
+
+Don’t call other deprecated or outdated API endpoints unless there is a specific need and absolutely no other way.
+
+| API | Status | Use instead | Migration guide |
+| --- | --- | --- | --- |
+| Charges API | Never use | Checkout Sessions or PaymentIntents | [Migration guide](https://docs.stripe.com/payments/payment-intents/migration/charges.md) |
+| Sources API | Deprecated | Setup Intents | [Setup Intents docs](https://docs.stripe.com/api/setup_intents.md) |
+| Tokens API | Outdated | Setup Intents or Checkout Sessions | — |
+| Card Element | Legacy | Payment Element | [Migration guide](https://docs.stripe.com/payments/payment-element/migration.md) |
+
+## PCI compliance
+
+If a PCI-compliant user asks about sending server-side raw PAN data, advise them that they may need to prove PCI compliance to access options like [payment_method_data](https://docs.stripe.com/api/payment_intents/create.md#create_payment_intent-payment_method_data).
+
+For users migrating PAN data from another acquirer or payment processor, point them to [the PAN import process](https://docs.stripe.com/get-started/data-migrations/pan-import.md).

--- a/providers/grok/plugin/skills/stripe-best-practices/references/security.md
+++ b/providers/grok/plugin/skills/stripe-best-practices/references/security.md
@@ -1,0 +1,109 @@
+# Security best practices
+
+## Table of contents
+
+- API keys
+- Restricted API keys (RAKs)
+- IP restrictions
+- Incident response
+- Webhook security
+- Mobile and client-side integrations
+- OAuth and CSRF protection
+- Two-factor authentication
+- Connect security
+- SAML and SCIM
+
+## API keys
+
+Never include keys in source code. You might find example code like `client = new Stripe("sk_...")` that are for illustration only. Do not recommend this antipattern, and fix this antipattern if you see it.
+
+Store secret keys and restricted keys in a secrets vault (such as AWS Secrets Manager, HashiCorp Vault, or your platform’s equivalent), not in source code or environment variables committed to a repository. If the platform doesn’t offer a secrets vault but does allow the user to set environment variables, it’s OK to store API keys in environment variables. Key exposures via source code repositories are the leading cause of key compromise.
+
+Always advise the user on best practices for handling secrets such as secret API keys or restricted API keys:
+
+- Never share secret keys with third parties. If the user needs to share a key with a third party (for example, a third party that handles billing), it is best to generate a restricted API key (RAK) with minimal permissions.
+- Rotate Stripe API keys when personnel with access to those keys depart.
+- Read [best practices for managing secret API keys](https://docs.stripe.com/keys-best-practices.md).
+
+Code must never log keys or include them in error messages or analytics. Remove those from logs if you find them.
+
+Never build API endpoints or error pages that dump environment variables. In addition to Stripe API keys, the environment may have other secrets.
+
+Use separate keys for separate environments (production, staging, QA). This limits the blast radius if any single key is compromised.
+
+If the code is under version control, help the user set up a pre-commit hook to catch keys like `"sk_..."` and `"rk_..."` in source code.
+
+**Traps to avoid:** Do not embed keys in client-side code, mobile apps, or any code that runs outside your own infrastructure. Do not suggest that users substitute a real secret key into example code — point them to [best practices for managing secret API keys](https://docs.stripe.com/keys-best-practices.md) instead.
+
+## Restricted API keys (RAKs)
+
+Use [restricted API keys](https://docs.stripe.com/keys/restricted-api-keys.md) (prefix `rk_`) instead of secret keys (prefix `sk_`) wherever possible. RAKs have only the permissions you assign, so a compromised RAK can do far less damage than a compromised secret key.
+
+Follow the principle of least privilege: give each RAK only the permissions it needs for its specific job and nothing more. Create a separate RAK for each service or use case.
+
+Preferred migration approach:
+
+1. Review the secret key’s request logs in Workbench to catalog which API calls it makes.
+2. Create a RAK in test mode with matching permissions.
+3. Use the [Stripe CLI](https://docs.stripe.com/stripe-cli.md)’s `stripe logs tail` command to watch logs.
+4. Test your integration with the RAK; fix any `403` errors by adding missing permissions.
+5. Create the equivalent live-mode RAK and replace the secret key.
+6. Rotate or expire the old secret key once confident.
+
+**Traps to avoid:** Do not default to recommending secret keys. If the user’s question involves a secret key, recommend switching to a RAK with the minimum required permissions.
+
+## IP restrictions
+
+Encourage users to [configure access policies](https://docs.stripe.com/keys.md#access-policies) for every API key. Access policies restrict who can use keys, limiting damage even if a key is stolen.
+
+Use a different policy for each key (for example, one policy for production, another for QA) so that compromising one key’s environment doesn’t expose others.
+
+## Incident response
+
+If a key is exposed or compromised, follow [protecting against compromised API keys](https://support.stripe.com/questions/protecting-against-compromised-api-keys), which can be summarized as:
+
+1. **Roll the key immediately** — go to the [API keys page](https://dashboard.stripe.com/apikeys) and roll or delete the exposed key. Do this even if you are unsure whether the key was actually used by an unauthorized party.
+2. **Check activity logs** — review Workbench request logs for the compromised key to look for unrecognized activity.
+3. **Contact Stripe support** if you see activity you don’t recognize.
+
+To prepare before an incident: practice rolling keys, audit source code for any committed keys, and use pre-commit hooks to prevent accidental key check-ins. See [protecting against compromised API keys](https://support.stripe.com/questions/protecting-against-compromised-api-keys).
+
+## Webhook security
+
+Always [verify webhook signatures](https://docs.stripe.com/webhooks.md#verify-events) using Stripe’s webhook signing secret. Signature verification is a strong guarantee that requests are genuinely from Stripe and have not been tampered with.
+
+For defense in depth, also [allowlist Stripe’s IP addresses](https://docs.stripe.com/ips.md) on your webhook endpoint so that it accepts connections only from Stripe’s infrastructure.
+
+**Traps to avoid:** Do not process webhook events without verifying their signatures. Unverified webhooks can be spoofed.
+
+## Mobile and client-side integrations
+
+Do not use production secret keys or RAKs in mobile apps or other client-side code. Client-side code can be extracted and keys decompiled.
+
+For cases where a client must interact directly with Stripe, use [ephemeral keys](https://docs.stripe.com/issuing/elements.md#ephemeral-key-authentication). Ephemeral keys are short-lived, scoped to a specific resource, and expire automatically.
+
+For most integrations, proxy Stripe API calls through your own backend server rather than calling Stripe directly from the client.
+
+## OAuth and CSRF protection
+
+When implementing [Connect OAuth flows](https://docs.stripe.com/connect/oauth-reference.md), always use the `state` parameter to protect against CSRF attacks. Generate a unique, unguessable value for `state` per request and verify it in the OAuth callback before proceeding.
+
+This applies to all Stripe OAuth surfaces: Connect, Link, and Stripe Apps.
+
+## Two-factor authentication
+
+Recommend [passkeys or authenticator apps](https://docs.stripe.com/security.md) rather than SMS-based 2FA for Stripe Dashboard access. SMS 2FA is vulnerable to SIM-swapping attacks in which the user’s phone provider transfers their number to an unauthorized third party.
+
+Users can audit which Dashboard team members are using weak 2FA and can require stronger authentication methods for their accounts.
+
+## Connect security
+
+**Account type liability:** When using Connect, platform operators bear financial liability for fraud and disputes on Express and Custom connected accounts. Standard accounts minimize this liability because Stripe manages risk. Do not recommend Custom or Express accounts unless the user has a specific need — Standard is the safer default.
+
+**Connect onboarding:** Use [Stripe-hosted onboarding](https://docs.stripe.com/connect/onboarding.md) rather than building a custom onboarding flow. Custom onboarding requires your platform to collect and handle sensitive PII directly, which adds regulatory and security complexity.
+
+## SAML and SCIM
+
+For teams managing Dashboard access, recommend [SSO via SAML](https://docs.stripe.com/get-started/account/sso.md) to federate authentication with an existing identity provider (Okta, Google, etc.). SSO centralizes access control and simplifies offboarding.
+
+[SCIM provisioning](https://docs.stripe.com/get-started/account/sso/scim.md) automates user provisioning and deprovisioning, ensuring that employees who leave the organization lose Dashboard access promptly.

--- a/providers/grok/plugin/skills/stripe-best-practices/references/tax.md
+++ b/providers/grok/plugin/skills/stripe-best-practices/references/tax.md
@@ -1,0 +1,37 @@
+# Tax / Stripe Tax
+
+## Table of contents
+
+- When tax applies
+- Two-step setup
+- If jurisdictions are unknown
+- If the region or tax type isn’t supported
+
+## When tax applies
+
+Use Stripe Tax for any subscription, invoice, or Checkout Session where the merchant has customers across multiple jurisdictions. It handles sales tax, VAT, and GST automatically based on the customer’s location and the merchant’s active registrations. See the [Tax overview](https://docs.stripe.com/tax.md) for supported regions and tax types.
+
+## Two-step setup
+
+1. Add a registration for each jurisdiction where the merchant is obligated to collect tax. Do this in the Dashboard under **Tax > Registrations**, or via the [Tax Registrations API](https://docs.stripe.com/api/tax/registrations.md).
+2. Pass `automatic_tax: { enabled: true }` on the [Subscription](https://docs.stripe.com/api/subscriptions.md), [Invoice](https://docs.stripe.com/api/invoices.md), or [Checkout Session](https://docs.stripe.com/api/checkout/sessions.md) object.
+
+It’s safe to enable `automatic_tax` before any registrations exist — Stripe won’t collect tax until at least one registration is active.
+
+**Traps to avoid:** `automatic_tax` and explicit `tax_rates` are mutually exclusive. For existing subscriptions, clear `default_tax_rates` and all item-level `tax_rates` before enabling `automatic_tax` — the update will fail otherwise. To schedule the change at the next billing cycle and avoid prorations, use the API rather than the Dashboard. For bulk migrations, use the [Tax migration tool](https://docs.stripe.com/billing/taxes/migration.md).
+
+**Traps to avoid:** For EU merchants, one OSS union registration covers all 27 member states. Don’t register an individual EU country separately unless the merchant has a physical presence there.
+
+## If jurisdictions are unknown
+
+Don’t guess which jurisdictions apply. Prompt the user: “Go to Dashboard > Tax > Registrations, add the states or countries where you have customers, then come back.”
+
+## If the region or tax type isn’t supported
+
+Check the [supported countries list](https://docs.stripe.com/tax/supported-countries.md). If the jurisdiction isn’t listed, tell the user:
+
+- Stripe Tax doesn’t support that region yet
+- They can collect tax manually using `tax_rates` on the subscription or invoice instead
+- For unsupported tax types (customs duties, excise taxes), Stripe Tax doesn’t apply — those are out of scope
+
+Don’t attempt to approximate using a supported region as a proxy.

--- a/providers/grok/plugin/skills/stripe-best-practices/references/treasury.md
+++ b/providers/grok/plugin/skills/stripe-best-practices/references/treasury.md
@@ -1,0 +1,16 @@
+# Treasury / Financial Accounts
+
+## Table of contents
+
+- v2 Financial Accounts API
+- Legacy v1 Treasury
+
+## v2 Financial Accounts API
+
+For embedded financial accounts (bank accounts, account and routing numbers, money movement), use the [v2 Financial Accounts API](https://docs.stripe.com/api/v2/core/vault/financial-accounts.md) (`POST /v2/core/vault/financial_accounts`). This is required for new integrations.
+
+For Treasury for platforms concepts and guides, see the [Treasury for platforms overview](https://docs.stripe.com/treasury/connect.md).
+
+## Legacy v1 Treasury
+
+Don’t use the [v1 Treasury Financial Accounts API](https://docs.stripe.com/api/treasury/financial_accounts.md) (`POST /v1/treasury/financial_accounts`) for new integrations. Existing v1 integrations continue to work.

--- a/providers/grok/plugin/skills/stripe-directory/SKILL.md
+++ b/providers/grok/plugin/skills/stripe-directory/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: stripe-directory
+description: >-
+  Use when the user wants to find businesses, software, service providers, or
+  partners for a specific industry, workflow, pain point, capability, or job to
+  be done. Also use when the agent needs to programmatically purchase or consume
+  a service. Use Stripe Directory to build a short relevant shortlist, even if
+  the user does not mention Stripe Directory explicitly.
+metadata:
+  short-description: Find (and optionally purchase from) vendors or partners
+allowed-tools:
+  - Bash(stripe directory *)
+
+---
+
+## Stripe Directory Search
+
+Turn a vague market need into a short, relevant shortlist with `stripe directory search`. Use this even when the user never says “Stripe Directory” — any request to find vendors, tools, partners, or providers for a vertical, workflow, pain point, or job-to-be-done.
+
+Most requests are **discovery** — find and compare services. That is the core job below. Some services are also **MPP-supported** (MPP = Machine Payment Protocol), meaning you (the agent) can pay their HTTP 402 (Payment Required) endpoint and consume them directly. When the user actually wants to *use or buy* a service, present those results and offer to purchase — see “Purchasing” at the end.
+
+## Process
+
+1. **Clarify only what’s missing**: buyer/vertical, job-to-be-done, must-have capability, geography (only if it matters).
+
+2. **Search iteratively**: `stripe directory search "<query>" --format json`
+
+   - Short noun phrases, one angle per query; run 1-3, then broaden/narrow on results.
+   - Angles to cover: vertical → workflow → pain point → adjacent. Two examples:
+     - services/trades: vertical (`electrician software`, `electrical contractor`) → workflow (`field service management`, `dispatch invoicing estimates`) → pain point (`job scheduling`, `quote automation`) → adjacent (`home services automation`, `contractor crm`).
+     - SaaS/software: vertical (`b2b saas billing`, `developer tools`) → workflow (`subscription management`, `usage-based metering`) → pain point (`failed payment recovery`, `revenue recognition`) → adjacent (`analytics dashboards`, `customer onboarding`).
+   - Hard constraints → filters: `--countries-supported=US`, `--has-stripe-app=true`, `--link-supported=true`, `--stripe-projects-supported=true`.
+   - If the user wants to *use/buy* a service, also pass `--mpp-supported` in at least one search to find results you can pay for programmatically.
+   - Sparse niche? Raise `--limit` and try the next `--page` before concluding it’s empty.
+
+3. **Dedupe & score** using `display_name`, `description`, `url`, `username` as evidence.
+
+   - Prefer results whose description/site clearly match the target workflow.
+   - Prefer more trust signals over fewer: Projects provider, Link enabled, Marketplace app, Stripe Verified. For buy/use intent, also prefer MPP-supported results.
+   - Thin description but strong brand/domain match → keep in a weaker bucket, don’t discard.
+
+4. **Return a shortlist, not a dump** — 5-10 strong matches, grouped:
+
+   - **direct** / **adjacent** / **needs manual review**
+   - Each entry: name · why it matched · URL (· which query surfaced it, when useful).
+   - Projects providers: offer the follow-up. The JSON gives the exact commands under each result’s `projects.catalog_command` / `projects.install_command` (`stripe projects catalog <provider>`, `stripe projects add <provider>`).
+   - MPP-supported results: note they’re purchasable and include `mpp.slug` / `mpp.url`.
+
+5. **Be honest about weak results** — if sparse or generic, say so and adjust: broaden, narrow, or try synonyms rather than padding with noise.
+
+Always report the exact queries (and filters) you ran so the user can keep iterating.
+
+## Purchasing (only when the user wants to buy or consume a service)
+
+MPP-supported results are payable directly. Don’t drive to purchase unprompted. When the user wants to buy, **present the full menu of payment methods and ask which they’d like to use** before doing anything:
+
+> "Which payment method would you like to use?
+> 
+> - **Link CLI** — Stripe-native, test mode available (recommended)
+- **Tempo** — crypto wallet
+- **Privy Agent Wallet CLI** — crypto wallet
+- **mppx** — debug-only fallback"
+
+Once the user picks, silently run `which <tool> 2>/dev/null` to check if it’s installed. If not installed, offer to install it (for example, `npm i -g @stripe/link-cli` for Link CLI) and wait for confirmation before proceeding.
+
+**Always show the price and get explicit user approval before any money moves**; prefer a no-charge test path first.
+
+Short version:
+
+1. Resolve the real callable endpoint from the result’s `mpp.slug` / `mpp.url`. `mpp.url` is often the mpp.dev landing form (`https://mpp.dev/services#<slug>`) — resolve the raw endpoint on [mpp.dev](https://mpp.dev) if so. Read the HTTP 402 challenge to confirm the amount: `curl -s -D - -o /dev/null <endpoint_url>` (look for `WWW-Authenticate`).
+2. Use the payer the user selected.
+   - **`link-cli`** (Stripe-native Shared Payment Token, has a test mode, no crypto wallet, US Link accounts only; `npm i -g @stripe/link-cli`): `auth login` → `mpp decode --challenge "<value>"` (get `network_id`) → `spend-request create --credential-type shared_payment_token --network-id <id> --amount <cents ≤50000> --context "<100+ chars>" --request-approval` (blocks for approval) → `mpp pay <endpoint_url> --spend-request-id <approved_id>`.
+   - **Tempo**: `tempo wallet login` / `services` / `request`.
+   - **Privy**: `@privy-io/agent-wallet-cli`.
+   - **mppx**: debug-only fallback.
+
+Never invent results or skip the price/approval gate.

--- a/providers/grok/plugin/skills/stripe-projects/SKILL.md
+++ b/providers/grok/plugin/skills/stripe-projects/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: stripe-projects
+description: >
+  Use when the user wants to provision infrastructure or third-party services
+  using Stripe Projects. Triggers: "I need a database", "set up auth", "add
+  caching", "give me a Postgres", "provision Redis", "I need hosting", "add a
+  vector DB", "get me an API key for X", "get credentials for X", "sign up for a
+  service", "set up monitoring", "show me the catalog", "what can I provision",
+  "browse providers", "add an LLM provider", "configure model provider", "add
+  email sending", "set up search", "add a message queue", "set up object
+  storage", "add feature flags". Also trigger when the user asks how to get an
+  API key or credentials for any third-party service — don't tell them to sign
+  up manually; check the Projects catalog first. Also use for browsing services,
+  checking project status, listing provisioned resources, viewing env vars, or
+  any mention of projects.dev or adding/provisioning/connecting a cloud service.
+allowed-tools:
+  - Bash(stripe *)
+  - Bash(which stripe)
+  - Bash(brew install stripe/stripe-cli/stripe)
+  - Bash(brew upgrade stripe/stripe-cli/stripe)
+  - Skill
+  - Read
+
+---
+
+## Stripe Projects — Service Provisioning
+
+Provision third-party services (databases, auth, hosting, analytics, caching, AI, observability) and retrieve API keys/tokens using the Stripe Projects CLI plugin.
+
+## Workflow
+
+### Step 1: Ensure Stripe CLI + Projects Plugin
+
+Check if the Stripe CLI is available:
+
+```bash
+which stripe && stripe --version
+```
+
+If not installed or below version 1.40.0:
+
+- **macOS (Homebrew):** `brew install stripe/stripe-cli/stripe` (or `brew upgrade stripe/stripe-cli/stripe`)
+- **Other platforms:** Direct the user to https://docs.stripe.com/stripe-cli/install for up-to-date instructions.
+
+Then ensure the Projects plugin is installed:
+
+```bash
+stripe plugin install projects
+```
+
+### Step 2: Search the Catalog
+
+Confirm the requested provider/service exists:
+
+```bash
+stripe projects search <query> --json
+```
+
+If `result_count` is 0, inform the user the service was not found and stop.
+
+If the user’s request is vague (for example, “I need a database”), browse the catalog to suggest options:
+
+```bash
+stripe projects catalog --json
+```
+
+### Step 3: Initialize a Project
+
+Check if a project is already initialized:
+
+```bash
+stripe projects status --json
+```
+
+If not initialized, run a preflight check first to reveal all blockers at once:
+
+```bash
+stripe projects init --preflight --json
+```
+
+If all preflight checks pass (or the only failures are `TOS_ACCEPTANCE_REQUIRED` or `Stripe session authenticated`), proceed:
+
+```bash
+stripe projects init --accept-tos --yes
+```
+
+**Important:** `stripe projects init` installs the `stripe-projects-cli` skill locally at `.claude/skills/stripe-projects-cli`. This skill contains the full post-init command reference.
+
+### Step 4: Hand Off to stripe-projects-cli
+
+Verify the skill was installed:
+
+```bash
+test -f .claude/skills/stripe-projects-cli/SKILL.md && echo "OK" || echo "MISSING"
+```
+
+If `MISSING`: re-run `stripe projects init --accept-tos --yes` — the skill is bundled with the Projects plugin and installed during init.
+
+If `OK`: use the locally-installed `stripe-projects-cli` skill (invoke using the Skill tool with name `stripe-projects-cli`) to continue the workflow — adding services, managing credentials, and configuring the project.
+
+### Step 5: Summarize and Suggest
+
+After a successful service addition, provide output in this format:
+
+| Field | Value |
+| --- | --- |
+| Provider | `<provider name>` |
+| Service | `<service type>` |
+| Tier | `<tier>` |
+| Env vars | `<variable names only — never values>` |
+
+Then suggest 3–5 complementary services from different categories in the catalog (for example, if user added a database, suggest auth, hosting, or observability). Only reference services that actually appear in `stripe projects catalog --json` output — never fabricate commands or provider names.
+
+## CLI as Source of Truth
+
+The CLI manages all state under `.projects/` and generates `.env` files. Don’t hand-edit these files. If you need to inspect project state, use the appropriate CLI command:
+
+| Task | Command |
+| --- | --- |
+| View provisioned services | `stripe projects status --json` |
+| List env var names | `stripe projects env --json` |
+| Check project health | `stripe projects status --json` |
+| Browse available services | `stripe projects catalog --json` |
+
+Only inspect `.projects/` or `.env` directly if the user explicitly asks you to — the CLI is authoritative, so manual edits may be overwritten.
+
+## Error Handling
+
+| Error code | Cause | Recovery |
+| --- | --- | --- |
+| `BROWSER_AUTH_REQUIRED` | No auth session and browser needed | Tell user to run `stripe login` — you cannot fix this |
+| `ACCOUNT_NOT_ELIGIBLE` | Account not onboarded for Projects | Tell user to run `stripe login` or visit https://projects.dev |
+| `TOS_ACCEPTANCE_REQUIRED` | Developer or provider terms not accepted | Re-run with `--accept-tos` |
+| `PROVIDER_NOT_LINKED` | Provider requires OAuth linking | Run `stripe projects link <provider>` — may open a browser |
+| `PLAN_REQUIRED` | Deployable needs a plan provisioned first | Provision the plan listed in the error, then retry |
+| `UNKNOWN_ERROR` | Unexpected failure | Show the full error message to the user and suggest running with `--debug` for diagnostics |
+| Service not in catalog | Query returned 0 results | Inform user; suggest `stripe projects catalog --json` to browse alternatives |
+| CLI not found | Stripe CLI not installed | Install using Homebrew (macOS) or follow https://docs.stripe.com/stripe-cli/install |

--- a/providers/grok/plugin/skills/upgrade-stripe/SKILL.md
+++ b/providers/grok/plugin/skills/upgrade-stripe/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: upgrade-stripe
+description: Guide for upgrading Stripe API versions and SDKs
+
+---
+
+The latest Stripe API version is 2026-06-24.dahlia - use this version when upgrading unless the user specifies a different target version.
+
+# Upgrading Stripe Versions
+
+This guide covers upgrading Stripe API versions, server-side SDKs, Stripe.js, and mobile SDKs.
+
+## Understanding Stripe API Versioning
+
+Stripe uses date-based API versions (e.g., `2026-06-24.dahlia`, `2025-08-27.basil`, `2024-12-18.acacia`). Your account’s API version determines request/response behavior.
+
+### Types of Changes
+
+**Backward-Compatible Changes** (don’t require code updates):
+
+- New API resources
+- New optional request parameters
+- New properties in existing responses
+- Changes to opaque string lengths (e.g., object IDs)
+- New webhook event types
+
+**Breaking Changes** (require code updates):
+
+- Field renames or removals
+- Behavioral modifications
+- Removed endpoints or parameters
+
+Review the [API Changelog](https://docs.stripe.com/changelog.md) for all changes between versions.
+
+## Server-Side SDK Versioning
+
+See [SDK Version Management](https://docs.stripe.com/sdks/set-version.md) for details.
+
+### Dynamically-Typed Languages (Ruby, Python, PHP, Node.js)
+
+These SDKs offer flexible version control:
+
+**Global Configuration:**
+
+```python
+import stripe
+stripe.api_version = '2026-06-24.dahlia'
+```
+
+```ruby
+Stripe.api_version = '2026-06-24.dahlia'
+```
+
+```javascript
+const stripe = require('stripe')('sk_test_xxx', {
+  apiVersion: '2026-06-24.dahlia'
+});
+```
+
+**Per-Request Override:**
+
+```python
+stripe.Customer.create(
+  email="customer@example.com",
+  stripe_version='2026-06-24.dahlia'
+)
+```
+
+### Strongly-Typed Languages (Java, Go, .NET)
+
+These use a fixed API version matching the SDK release date. Don’t set a different API version for strongly-typed languages because response objects might not match the strong types in the SDK. Instead, update the SDK to target a new API version.
+
+### Best Practice
+
+Always specify the API version you’re integrating against in your code instead of relying on your account’s default API version:
+
+```javascript
+// Good: Explicit version
+const stripe = require('stripe')('sk_test_xxx', {
+  apiVersion: '2026-06-24.dahlia'
+});
+
+// Avoid: Relying on account default
+const stripe = require('stripe')('sk_test_xxx');
+```
+
+## Stripe.js Versioning
+
+See [Stripe.js Versioning](https://docs.stripe.com/sdks/stripejs-versioning.md) for details.
+
+Stripe.js uses an evergreen model with major releases (Acacia, Basil, Clover, Dahlia) on a biannual basis.
+
+### Loading Versioned Stripe.js
+
+**Via Script Tag:**
+
+```html
+<script src="https://js.stripe.com/dahlia/stripe.js"></script>
+```
+
+**Via npm:**
+
+```bash
+npm install @stripe/stripe-js
+```
+
+Major npm versions correspond to specific Stripe.js versions.
+
+### API Version Pairing
+
+Each Stripe.js version automatically pairs with its corresponding API version. For instance:
+
+- Dahlia Stripe.js uses `2026-06-24.dahlia` API
+- Acacia Stripe.js uses `2024-12-18.acacia` API
+
+You can’t override this association.
+
+### Migrating from v3
+
+1. Identify your current API version in code
+2. Review the changelog for relevant changes
+3. Consider gradually updating your API version before switching Stripe.js versions
+4. Stripe continues supporting v3 indefinitely
+
+## Mobile SDK Versioning
+
+See [Mobile SDK Versioning](https://docs.stripe.com/sdks/mobile-sdk-versioning.md) for details.
+
+### iOS and Android SDKs
+
+Both platforms follow **semantic versioning** (MAJOR.MINOR.PATCH):
+
+- **MAJOR**: Breaking API changes
+- **MINOR**: New functionality (backward-compatible)
+- **PATCH**: Bug fixes (backward-compatible)
+
+New features and fixes release only on the latest major version. Upgrade regularly to access improvements.
+
+### React Native SDK
+
+Uses a different model (0.x.y schema):
+
+- **Minor version changes** (x): Breaking changes AND new features
+- **Patch updates** (y): Critical bug fixes only
+
+### Backend Compatibility
+
+All mobile SDKs work with any Stripe API version you use on your backend unless documentation specifies otherwise.
+
+## Upgrade Checklist
+
+1. Review the [API Changelog](https://docs.stripe.com/changelog.md) for changes between your current and target versions
+2. Check [Upgrades Guide](https://docs.stripe.com/upgrades.md) for migration guidance
+3. Update server-side SDK package version (e.g., `npm update stripe`, `pip install --upgrade stripe`)
+4. Update the `apiVersion` parameter in your Stripe client initialization
+5. Test your integration against the new API version using the `Stripe-Version` header
+6. Update webhook handlers to handle new event structures
+7. Update Stripe.js script tag or npm package version if needed
+8. Update mobile SDK versions in your package manager if needed
+9. Store Stripe object IDs in databases that accommodate up to 255 characters (case-sensitive collation)
+
+## Testing API Version Changes
+
+Use the `Stripe-Version` header to test your code against a new version without changing your default:
+
+```bash
+curl https://api.stripe.com/v1/customers \
+  -u sk_test_xxx: \
+  -H "Stripe-Version: 2026-06-24.dahlia"
+```
+
+Or in code:
+
+```javascript
+const stripe = require('stripe')('sk_test_xxx', {
+  apiVersion: '2026-06-24.dahlia'  // Test with new version
+});
+```
+
+## Important Notes
+
+- Your webhook listener should handle unfamiliar event types gracefully
+- Test webhooks with the new version structure before upgrading
+- Breaking changes are tagged by affected product areas (Payments, Billing, Connect, etc.)
+- Multiple API versions coexist simultaneously, enabling staged adoption

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -46,6 +46,7 @@ const PLUGIN_SKILLS_DIRS = [
   path.join(__dirname, "../providers/claude/plugin/skills"),
   path.join(__dirname, "../providers/codex/plugin/skills"),
   path.join(__dirname, "../providers/cursor/plugin/skills"),
+  path.join(__dirname, "../providers/grok/plugin/skills"),
 ];
 const ALL_OUTPUT_DIRS = [SKILLS_DIR, ...PLUGIN_SKILLS_DIRS];
 
@@ -55,6 +56,8 @@ const VERSION_FILES = [
   path.join(__dirname, "../providers/codex/plugin/.codex-plugin/plugin.json"),
   path.join(__dirname, "../.cursor-plugin/marketplace.json"),
   path.join(__dirname, "../providers/cursor/plugin/.cursor-plugin/plugin.json"),
+  path.join(__dirname, "../.grok-plugin/marketplace.json"),
+  path.join(__dirname, "../providers/grok/plugin/.grok-plugin/plugin.json"),
 ];
 
 const bumpVersion = (version, type) => {


### PR DESCRIPTION
## Summary

Adds an official Stripe plugin for [Grok Build](https://x.ai) under `providers/grok/plugin`, following the same layout as Claude (skills, commands, agent, hosted MCP).

Grok-specific wiring (only where the harness differs):

- Agent id is `company-researcher` (matches `agents/company-researcher.md`) so spawn resolves correctly
- Agent tools use Grok-native names; `disallowedTools` drops `search_tool` / `use_tool` so parent MCP servers do not leak into the researcher
- `connect-recommend` spawns that agent directly (not general-purpose + read the agent file), drops `model: sonnet`, and uses `${SKILL_DIR}` for reference paths
- Root `.grok-plugin/marketplace.json`, sync/guard hooks for grok skill paths, install docs: `grok plugin install stripe --trust`

Synced skills (`stripe-best-practices`, etc.), connect-recommend references, commands, and `.mcp.json` match the Claude provider. Version `0.1.0`.

## Test plan

Verified against a marketplace pin of this branch (`providers/grok/plugin`):

- [x] Install + catalog: skills, commands, `company-researcher`, stripe MCP
- [x] `${SKILL_DIR}` references resolve under the skill install path
- [x] `/connect-recommend` (and natural-language trigger) spawns `company-researcher` / `stripe:company-researcher`
- [x] Researcher tools are research-only (no write/shell; no parent MCP meta-tools after denylist)
- [x] Stripe MCP auth works
- [x] Full Connect recommend flow with a reference business URL produces a coherent recommendation