### PR TITLE
fix: check both dash-form and dot-form model IDs in getDefaultMaxTokens

### DIFF
--- a/llm/ai-sdk/provider/stripe-language-model-v3.ts
+++ b/llm/ai-sdk/provider/stripe-language-model-v3.ts
@@ -185,15 +185,22 @@ export class StripeLanguageModelV3 implements LanguageModelV3 {
 
     const model = modelId.substring('anthropic/'.length);
 
+    // Check both dash-form (claude-3-7-sonnet) and dot-form (claude-3.7-sonnet)
+    // since normalizeModelId converts version dashes to dots
     if (
       model.includes('sonnet-4') ||
       model.includes('claude-3-7-sonnet') ||
-      model.includes('haiku-4-5')
+      model.includes('claude-3.7-sonnet') ||
+      model.includes('haiku-4-5') ||
+      model.includes('haiku-4.5')
     ) {
       return 64000;
     } else if (model.includes('opus-4')) {
       return 32000;
-    } else if (model.includes('claude-3-5-haiku')) {
+    } else if (
+      model.includes('claude-3-5-haiku') ||
+      model.includes('claude-3.5-haiku')
+    ) {
       return 8192;
     } else {
       return 4096;

--- a/llm/ai-sdk/provider/stripe-language-model.ts
+++ b/llm/ai-sdk/provider/stripe-language-model.ts
@@ -208,19 +208,25 @@ export class StripeLanguageModel implements LanguageModelV2 {
     const model = modelId.substring('anthropic/'.length);
 
     // Claude Sonnet 4 models (including variants like sonnet-4-1) and 3.7 Sonnet
-    if (model.includes('sonnet-4') || 
-        model.includes('claude-3-7-sonnet') || 
-        model.includes('haiku-4-5')) {
+    // Check both dash-form (claude-3-7-sonnet) and dot-form (claude-3.7-sonnet)
+    // since normalizeModelId converts version dashes to dots
+    if (model.includes('sonnet-4') ||
+        model.includes('claude-3-7-sonnet') ||
+        model.includes('claude-3.7-sonnet') ||
+        model.includes('haiku-4-5') ||
+        model.includes('haiku-4.5')) {
       return 64000; // 64K tokens
-    } 
+    }
     // Claude Opus 4 models (including variants like opus-4-1)
     else if (model.includes('opus-4')) {
       return 32000; // 32K tokens
-    } 
+    }
     // Claude 3.5 Haiku
-    else if (model.includes('claude-3-5-haiku')) {
+    // Check both dash-form (claude-3-5-haiku) and dot-form (claude-3.5-haiku)
+    else if (model.includes('claude-3-5-haiku') ||
+             model.includes('claude-3.5-haiku')) {
       return 8192; // 8K tokens
-    } 
+    }
     // Default fallback for other Anthropic models
     else {
       return 4096;

--- a/llm/ai-sdk/provider/tests/stripe-language-model-v3.test.ts
+++ b/llm/ai-sdk/provider/tests/stripe-language-model-v3.test.ts
@@ -422,6 +422,64 @@ describe('StripeLanguageModelV3', () => {
       expect(args.max_tokens).toBeUndefined();
     });
 
+    it('should apply correct defaults for normalized (dot-form) model IDs', () => {
+      const testCases = [
+        {modelId: 'anthropic/claude-3.7-sonnet', expected: 64000},
+        {modelId: 'anthropic/claude-3.5-haiku', expected: 8192},
+        {modelId: 'anthropic/claude-haiku-4.5', expected: 64000},
+        {modelId: 'anthropic/claude-opus-4', expected: 32000},
+        {modelId: 'anthropic/claude-sonnet-4', expected: 64000},
+      ];
+
+      testCases.forEach(({modelId, expected}) => {
+        const m = new StripeLanguageModelV3(
+          modelId,
+          {customerId: 'cus_test'},
+          {
+            provider: 'stripe',
+            baseURL: 'https://llm.stripe.com',
+            headers: () => ({}),
+          }
+        );
+
+        const options: LanguageModelV3CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = m.getArgs(options);
+        expect(args.max_tokens).toBe(expected);
+      });
+    });
+
+    it('should apply correct defaults for dash-form model IDs (pre-normalization)', () => {
+      const testCases = [
+        {modelId: 'anthropic/claude-3-7-sonnet', expected: 64000},
+        {modelId: 'anthropic/claude-3-5-haiku', expected: 8192},
+        {modelId: 'anthropic/claude-haiku-4-5', expected: 64000},
+      ];
+
+      testCases.forEach(({modelId, expected}) => {
+        const m = new StripeLanguageModelV3(
+          modelId,
+          {customerId: 'cus_test'},
+          {
+            provider: 'stripe',
+            baseURL: 'https://llm.stripe.com',
+            headers: () => ({}),
+          }
+        );
+
+        const options: LanguageModelV3CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = m.getArgs(options);
+        expect(args.max_tokens).toBe(expected);
+      });
+    });
+
     it('should allow user-provided maxOutputTokens to override default', () => {
       const sonnetModel = new StripeLanguageModelV3(
         'anthropic/claude-sonnet-4',

--- a/llm/ai-sdk/provider/tests/stripe-language-model.test.ts
+++ b/llm/ai-sdk/provider/tests/stripe-language-model.test.ts
@@ -421,6 +421,65 @@ describe('StripeLanguageModel', () => {
       expect(args.max_tokens).toBeUndefined();
     });
 
+    it('should apply correct defaults for normalized (dot-form) model IDs', () => {
+      // These are the IDs that normalizeModelId produces
+      const testCases = [
+        {modelId: 'anthropic/claude-3.7-sonnet', expected: 64000},
+        {modelId: 'anthropic/claude-3.5-haiku', expected: 8192},
+        {modelId: 'anthropic/claude-haiku-4.5', expected: 64000},
+        {modelId: 'anthropic/claude-opus-4', expected: 32000},
+        {modelId: 'anthropic/claude-sonnet-4', expected: 64000},
+      ];
+
+      testCases.forEach(({modelId, expected}) => {
+        const m = new StripeLanguageModel(
+          modelId,
+          {customerId: 'cus_test'},
+          {
+            provider: 'stripe',
+            baseURL: 'https://llm.stripe.com',
+            headers: () => ({}),
+          }
+        );
+
+        const options: LanguageModelV2CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = m.getArgs(options);
+        expect(args.max_tokens).toBe(expected);
+      });
+    });
+
+    it('should apply correct defaults for dash-form model IDs (pre-normalization)', () => {
+      const testCases = [
+        {modelId: 'anthropic/claude-3-7-sonnet', expected: 64000},
+        {modelId: 'anthropic/claude-3-5-haiku', expected: 8192},
+        {modelId: 'anthropic/claude-haiku-4-5', expected: 64000},
+      ];
+
+      testCases.forEach(({modelId, expected}) => {
+        const m = new StripeLanguageModel(
+          modelId,
+          {customerId: 'cus_test'},
+          {
+            provider: 'stripe',
+            baseURL: 'https://llm.stripe.com',
+            headers: () => ({}),
+          }
+        );
+
+        const options: LanguageModelV2CallOptions = {
+          prompt: [],
+        };
+
+        // @ts-expect-error - Accessing private method for testing
+        const {args} = m.getArgs(options);
+        expect(args.max_tokens).toBe(expected);
+      });
+    });
+
     it('should allow user-provided maxOutputTokens to override default', () => {
       const sonnetModel = new StripeLanguageModel(
         'anthropic/claude-sonnet-4',


### PR DESCRIPTION
## Summary

Fixes #432

 in both the V2 and V3 language models only checked for dash-form model ID patterns (e.g., `claude-3-7-sonnet`), but `normalizeModelId` converts version dashes to dots (e.g., `claude-3.7-sonnet`). This caused normalized Anthropic model IDs to silently fall back to the 4096 default instead of their intended values:

| Model | Expected | Actual (before fix) |
|-------|----------|-------------------|
| `anthropic/claude-3-7-sonnet` | 64000 | 64000 |
| `anthropic/claude-3.7-sonnet` (normalized) | 64000 | 4096 |
| `anthropic/claude-3-5-haiku` | 8192 | 8192 |
| `anthropic/claude-3.5-haiku` (normalized) | 8192 | 4096 |
| `anthropic/claude-haiku-4-5` | 64000 | 64000 |
| `anthropic/claude-haiku-4.5` (normalized) | 64000 | 4096 |

## Changes

- **`stripe-language-model.ts`**: Added dot-form pattern checks (`claude-3.7-sonnet`, `claude-3.5-haiku`, `haiku-4.5`) to `getDefaultMaxTokens`
- **`stripe-language-model-v3.ts`**: Same fix applied to the V3 implementation
- **Tests**: Added test cases for both normalized (dot-form) and dash-form model IDs in both V2 and V3 test suites

All 333 tests pass.