### PR TITLE
Remove local skills carve out

### DIFF
--- a/.github/workflows/guard-skills.yml
+++ b/.github/workflows/guard-skills.yml
@@ -6,13 +6,9 @@ on:
       - 'skills/**'
       - '!skills/README.md'
       - 'providers/claude/plugin/skills/**'
-      - '!providers/claude/plugin/skills/connect-recommend/**'
       - 'providers/codex/plugin/skills/**'
-      - '!providers/codex/plugin/skills/connect-recommend/**'
       - 'providers/cursor/plugin/skills/**'
-      - '!providers/cursor/plugin/skills/connect-recommend/**'
       - 'providers/grok/plugin/skills/**'
-      - '!providers/grok/plugin/skills/connect-recommend/**'
 
 jobs:
   block:

--- a/providers/README.md
+++ b/providers/README.md
@@ -10,7 +10,4 @@ Skills in `providers/*/plugin/skills/` are automatically synced from [docs.strip
 
 To manually trigger a sync, go to the [workflow page](https://github.com/stripe/agent-toolkit/actions/workflows/sync-skills.yml) and click "Run workflow".
 
-## Local-only skills
-
-`connect-recommend` is maintained per provider (not overwritten by the docs.stripe.com sync). Provider-specific wiring (subagent spawn, tool names, path tokens) lives there. Do not move Connect recommendation logic into the synced skill set without updating `LOCAL_SKILLS` in `scripts/sync.js`.
 

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -26,15 +26,11 @@ const fetchManifest = () => {
 
 const PRESERVE_FILES = new Set(["README.md", ".gitkeep"]);
 const OMIT_FILES = new Set(["metadata.yaml"]);
-// Skills that are locally managed and should not be removed during sync.
-// Add skill directory names here to protect them from being cleaned up.
-const LOCAL_SKILLS = new Set(["connect-recommend"]);
 
 const cleanDirectory = async (dir) => {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
     if (PRESERVE_FILES.has(entry.name)) continue;
-    if (entry.isDirectory() && LOCAL_SKILLS.has(entry.name)) continue;
     await fs.rm(path.join(dir, entry.name), { recursive: true, force: true });
   }
 };


### PR DESCRIPTION
Connect Recommend is not in the stripe docs, so this remove the special carve out we were making for this skill in the plugins.