### PR TITLE
Fix: use paths-ignore instead of negation in guard-skills workflow

### DIFF
--- a/.github/workflows/guard-skills.yml
+++ b/.github/workflows/guard-skills.yml
@@ -4,11 +4,12 @@ on:
   pull_request:
     paths:
       - 'skills/**'
-      - '!skills/README.md'
       - 'providers/claude/plugin/skills/**'
       - 'providers/codex/plugin/skills/**'
       - 'providers/cursor/plugin/skills/**'
       - 'providers/grok/plugin/skills/**'
+    paths-ignore:
+      - 'skills/README.md'
 
 jobs:
   block:


### PR DESCRIPTION
checked for failures with Copilot