### PR TITLE
Pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/guard-skills.yml
+++ b/.github/workflows/guard-skills.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ secrets.GH_APP_STRIPE_AI_SYNC_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_STRIPE_AI_SYNC_PEM }}
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build review body
         id: message
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const author = context.payload.pull_request.user.login;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,15 +22,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.11.0
 
       - name: Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "18"
 
@@ -62,15 +62,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.11.0
 
       - name: Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "18"
 
@@ -103,15 +103,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
 
       - name: Install
         run: make venv

--- a/.github/workflows/npm_release_shared.yml
+++ b/.github/workflows/npm_release_shared.yml
@@ -24,14 +24,14 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.11.0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
 
       - name: Install
         run: make venv
@@ -44,7 +44,7 @@ jobs:
           make test
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-dists
           path: ./tools/python/dist/
@@ -65,10 +65,10 @@ jobs:
 
     steps:
       - name: Retrieve distribution
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-dists
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
         
@@ -23,7 +23,7 @@ jobs:
         id: app-token
         if: |
           github.ref == 'refs/heads/main'
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ secrets.GH_APP_STRIPE_AI_SYNC_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_STRIPE_AI_SYNC_PEM }}
@@ -32,7 +32,7 @@ jobs:
           permission-contents: write
       
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '20'
 


### PR DESCRIPTION
### Notify
cc @stripe/developer-ai

### Summary
Pin all 23 third-party GitHub Action references in the affected workflows to immutable commit SHAs while retaining their version tags as comments.

### Motivation
Resolve [RUN_DEVAI-440](https://jira.corp.stripe.com/browse/RUN_DEVAI-440) and its `unpinned-uses` supply-chain security findings.

### Test plan
- [x] Ran `uvx zizmor` against all five affected workflows; no `unpinned-uses` findings remain
- [x] Parsed all five workflow files as YAML
- [x] Verified every `uses:` reference is pinned to a 40-character SHA
- [x] Ran `git diff --check`

### Rollout/revert plan
- [x] Safe to revert; this preserves the action versions currently in use

### Monitoring plan
- [x] Change has no runtime behavior impact beyond making action resolution immutable
