### PR TITLE
Document Agent Plugins install instructions for more clients

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "stripe",
+  "owner": {
+    "name": "Stripe",
+    "email": "support@stripe.com"
+  },
+  "plugins": [
+    {
+      "name": "stripe",
+      "source": "./providers/agent-plugins/plugin/",
+      "description": "Stripe agent plugin with skills for Stripe integrations including best practices, API and SDK upgrade guidance, and a remote MCP server configuration.",
+      "version": "0.1.3",
+      "author": {
+        "name": "Stripe"
+      }
+    }
+  ]
+}

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "stripe",
+  "version": "0.1.3",
+  "description": "Stripe agent plugin with skills for Stripe integrations including best practices, API and SDK upgrade guidance, and a remote MCP server configuration.",
+  "author": {
+    "name": "Stripe"
+  },
+  "homepage": "https://docs.stripe.com",
+  "license": "MIT",
+  "keywords": [
+    "stripe",
+    "payments",
+    "webhooks",
+    "api",
+    "security"
+  ],
+  "interface": {
+    "displayName": "Stripe",
+    "shortDescription": "Stripe integration skills, upgrade guidance, and a remote MCP server."
+  },
+  "skills": [
+    "./providers/agent-plugins/plugin/skills/connect-recommend",
+    "./providers/agent-plugins/plugin/skills/connect-required-verification-information",
+    "./providers/agent-plugins/plugin/skills/stripe-apps",
+    "./providers/agent-plugins/plugin/skills/stripe-best-practices",
+    "./providers/agent-plugins/plugin/skills/stripe-directory",
+    "./providers/agent-plugins/plugin/skills/stripe-docs",
+    "./providers/agent-plugins/plugin/skills/stripe-projects",
+    "./providers/agent-plugins/plugin/skills/upgrade-stripe"
+  ],
+  "mcpServers": {
+    "stripe": {
+      "url": "https://mcp.stripe.com"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ Run this command in your project:
 gemini extensions install https://github.com/stripe/ai
 ```
 
-Source: [Gemini CLI extensions docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/index.md).
-
 ### Kimi CLI
 
 Kimi CLI plugins use their own manifest format rather than the Agent Plugins
@@ -75,12 +73,6 @@ this command in your project:
 ```text
 /plugins install https://github.com/stripe/ai
 ```
-
-Sources: [Kimi Code CLI plugin docs](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins)
-([mirror source](https://github.com/MoonshotAI/kimi-code/blob/main/docs/en/customization/plugins.md)),
-and Kimi's own [`marketplace.json` example](https://github.com/MoonshotAI/kimi-code/blob/main/plugins/marketplace.json),
-which confirms Kimi's manifest fields (`plugins[].id`, `source`, `displayName`)
-rather than the Agent Plugins `plugin.json` shape used elsewhere in this repo.
 
 ### Agent Plugins
 
@@ -98,35 +90,6 @@ If your client isn't listed below, you can generally still point it at:
 - Git URL: `https://github.com/stripe/ai`
 - Subdirectory: [`providers/agent-plugins/plugin/`](/providers/agent-plugins/plugin).
 
-The clients below are drawn from the Agent Plugins spec's own
-[compatible clients list](https://agent-plugins.org/compatible-clients)
-([source](https://github.com/agentplugins/agent-plugins-site/blob/main/lib/compatible-clients.ts)).
-
-A few of these clients look for a bare, root-level `marketplace.json` (or a
-`.claude-plugin/marketplace.json`/`.cursor-plugin/marketplace.json` fallback),
-but they don't all parse the same schema. For example:
-- Claude Code's format requires a top-level `owner` object and per-plugin
-  `description`/`version`/`author` fields — see the
-  [Claude Code marketplace docs](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces).
-- Codex checks four candidate paths (`.agents/plugins/marketplace.json`,
-  `.agents/plugins/api_marketplace.json`, `.claude-plugin/marketplace.json`,
-  and `.cursor-plugin/marketplace.json` — notably *not* `.codex-plugin/marketplace.json`)
-  and additionally expects a Codex-specific `policy.installation`/
-  `policy.authentication` object and optional `category` per plugin, per the
-  `RawMarketplaceManifest`/`RawMarketplaceManifestPlugin` types in
-  [`codex-rs/core-plugins/src/marketplace.rs`](https://github.com/openai/codex/blob/main/codex-rs/core-plugins/src/marketplace.rs).
-- GitHub Copilot CLI checks `.github/plugin/marketplace.json` first, then
-  falls back to `.claude-plugin/marketplace.json`, and documents itself as
-  compatible with the Claude Code schema plus optional "Open Plugin Spec"
-  extensions — see the
-  [Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference).
-
-In short: several clients converge on (or fall back to) the schema Claude
-Code originated, but Codex's variant adds required fields Claude's doesn't
-have, and Cursor and Kimi use their own dedicated formats — so a listing
-built for one client isn't guaranteed to validate on another without checking
-that client's own docs or source first.
-
 #### GitHub Copilot CLI
 
 Run these commands in your project:
@@ -136,8 +99,6 @@ copilot plugin marketplace add stripe/ai
 copilot plugin install stripe@stripe
 ```
 
-Source: [Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference).
-
 #### VS Code
 
 Add this repo as a plugin marketplace in your `settings.json`, then install
@@ -146,8 +107,6 @@ Add this repo as a plugin marketplace in your `settings.json`, then install
 ```json
 "chat.plugins.marketplaces": ["stripe/ai"]
 ```
-
-Source: [VS Code Agent Plugins docs](https://code.visualstudio.com/docs/agent-customization/agent-plugins).
 
 #### OpenClaw
 
@@ -159,10 +118,6 @@ publishes the former for Claude Code. Run these commands in your project:
 openclaw plugins marketplace list stripe/ai
 openclaw plugins install stripe --marketplace stripe/ai
 ```
-
-Sources: [OpenClaw plugin bundles docs](https://docs.openclaw.ai/plugins/bundles)
-and the `MARKETPLACE_MANIFEST_CANDIDATES` constant in
-[`src/plugins/marketplace.ts`](https://github.com/openclaw/openclaw/blob/main/src/plugins/marketplace.ts).
 
 #### Hermes Agent
 
@@ -178,12 +133,6 @@ hermes plugins list
 hermes plugins enable stripe
 ```
 
-Sources: [Hermes Agent plugin docs](https://hermes-agent.nousresearch.com/docs/developer-guide/plugins#portable-agent-plugins-v1-packages),
-and the subdirectory-shorthand parsing in
-[`hermes_cli/plugin_packs.py`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/plugin_packs.py)
-and the `--enable`/`--no-enable` prompt-skip flags in
-[`hermes_cli/subcommands/plugins.py`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/subcommands/plugins.py).
-
 #### NanoClaw
 
 NanoClaw only stamps templates from a local directory, so copy the package in
@@ -195,15 +144,11 @@ cp -r /tmp/stripe-ai/providers/agent-plugins/plugin templates/stripe
 ncl groups create --template stripe --name "Stripe Agent" --yes
 ```
 
-Source: [NanoClaw templates docs](https://github.com/nanocoai/nanoclaw/blob/main/docs/templates.md).
-
 #### Kiro
 
 Kiro already lists Stripe in its curated registry. Browse to
 [kiro.dev/powers](https://kiro.dev/powers), find Stripe, and select
 **Add to Kiro** — no manual installation is required.
-
-Source: [Kiro powers docs](https://kiro.dev/docs/powers/).
 
 
 ## Manual installation

--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ gemini extensions install https://github.com/stripe/ai
 
 ### Kimi CLI
 
-Kimi CLI doesn't yet support installable agent plugins, but you can add our
-remote MCP server directly:
+Kimi CLI plugins use their own manifest format rather than the Agent Plugins
+standard, so this repo also publishes a [`.kimi-plugin/plugin.json`](/.kimi-plugin/plugin.json)
+manifest at its root that points at our existing skills and MCP server. Run
+this command in your project:
 
-```bash
-kimi mcp add --transport http stripe https://mcp.stripe.com --auth oauth
+```text
+/plugins install https://github.com/stripe/ai
 ```
 
 ### Agent Plugins
@@ -78,10 +80,11 @@ The [Agent Plugins](https://agent-plugins.org/) standard (formerly known as
 Open Plugins) defines a portable package format for skills and MCP servers,
 but leaves distribution and installation up to each client. This repo
 publishes a conformant package at
-[`providers/agent-plugins/plugin/`](/providers/agent-plugins/plugin) and a
-marketplace listing at [`.github/plugin/marketplace.json`](/.github/plugin/marketplace.json)
-that clients can use to install it directly from this repo, without waiting
-for a curated marketplace listing.
+[`providers/agent-plugins/plugin/`](/providers/agent-plugins/plugin) plus a
+[`.github/plugin/marketplace.json`](/.github/plugin/marketplace.json) listing
+that clients checking that path (for example GitHub Copilot CLI) can use to
+install it directly from this repo, without waiting for a curated marketplace
+listing.
 
 If your client isn't listed below, you can generally still point it at:
 - Git URL: `https://github.com/stripe/ai`
@@ -107,7 +110,9 @@ Add this repo as a plugin marketplace in your `settings.json`, then install
 
 #### OpenClaw
 
-Run these commands in your project:
+OpenClaw resolves marketplaces from a repo's `.claude-plugin/marketplace.json`,
+which this repo already publishes for Claude Code. Run these commands in your
+project:
 
 ```bash
 openclaw plugins marketplace list stripe/ai
@@ -116,10 +121,15 @@ openclaw plugins install stripe --marketplace stripe/ai
 
 #### Hermes Agent
 
-Run these commands in your project:
+Hermes's installer accepts an `owner/repo/<subdirectory>` shorthand, so you can
+point it directly at the package subdirectory. Portable Agent Plugins packages
+always install disabled — `--no-enable` just skips the interactive prompt so
+the command is non-interactive — so you'll need to enable it explicitly after
+reviewing it:
 
 ```bash
-hermes plugins install stripe/ai --no-enable
+hermes plugins install stripe/ai/providers/agent-plugins/plugin --no-enable
+hermes plugins list
 hermes plugins enable stripe
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,90 @@ Run this command in your project:
 grok plugin install stripe --trust
 ```
 
+### Gemini CLI
+
+Run this command in your project:
+
+```bash
+gemini extensions install https://github.com/stripe/ai
+```
+
+### Kimi CLI
+
+Kimi CLI doesn't yet support installable agent plugins, but you can add our
+remote MCP server directly:
+
+```bash
+kimi mcp add --transport http stripe https://mcp.stripe.com --auth oauth
+```
+
 ### Agent Plugins
 
-Installation methods currently vary by client for the new [Agent Plugins](https://agent-plugins.org/) standard, but you can point your client to our package via:
+The [Agent Plugins](https://agent-plugins.org/) standard (formerly known as
+Open Plugins) defines a portable package format for skills and MCP servers,
+but leaves distribution and installation up to each client. This repo
+publishes a conformant package at
+[`providers/agent-plugins/plugin/`](/providers/agent-plugins/plugin) and a
+marketplace listing at [`.github/plugin/marketplace.json`](/.github/plugin/marketplace.json)
+that clients can use to install it directly from this repo, without waiting
+for a curated marketplace listing.
+
+If your client isn't listed below, you can generally still point it at:
 - Git URL: `https://github.com/stripe/ai`
 - Subdirectory: [`providers/agent-plugins/plugin/`](/providers/agent-plugins/plugin).
+
+#### GitHub Copilot CLI
+
+Run these commands in your project:
+
+```bash
+copilot plugin marketplace add stripe/ai
+copilot plugin install stripe@stripe
+```
+
+#### VS Code
+
+Add this repo as a plugin marketplace in your `settings.json`, then install
+`stripe@stripe` from the Agent Plugins view in the Extensions sidebar:
+
+```json
+"chat.plugins.marketplaces": ["stripe/ai"]
+```
+
+#### OpenClaw
+
+Run these commands in your project:
+
+```bash
+openclaw plugins marketplace list stripe/ai
+openclaw plugins install stripe --marketplace stripe/ai
+```
+
+#### Hermes Agent
+
+Run these commands in your project:
+
+```bash
+hermes plugins install stripe/ai --no-enable
+hermes plugins enable stripe
+```
+
+#### NanoClaw
+
+NanoClaw only stamps templates from a local directory, so copy the package in
+before creating a group:
+
+```bash
+git clone --depth 1 https://github.com/stripe/ai /tmp/stripe-ai
+cp -r /tmp/stripe-ai/providers/agent-plugins/plugin templates/stripe
+ncl groups create --template stripe --name "Stripe Agent" --yes
+```
+
+#### Kiro
+
+Kiro already lists Stripe in its curated registry. Browse to
+[kiro.dev/powers](https://kiro.dev/powers), find Stripe, and select
+**Add to Kiro** — no manual installation is required.
 
 
 ## Manual installation

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Run this command in your project:
 gemini extensions install https://github.com/stripe/ai
 ```
 
+Source: [Gemini CLI extensions docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/index.md).
+
 ### Kimi CLI
 
 Kimi CLI plugins use their own manifest format rather than the Agent Plugins
@@ -73,6 +75,12 @@ this command in your project:
 ```text
 /plugins install https://github.com/stripe/ai
 ```
+
+Sources: [Kimi Code CLI plugin docs](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins)
+([mirror source](https://github.com/MoonshotAI/kimi-code/blob/main/docs/en/customization/plugins.md)),
+and Kimi's own [`marketplace.json` example](https://github.com/MoonshotAI/kimi-code/blob/main/plugins/marketplace.json),
+which confirms Kimi's manifest fields (`plugins[].id`, `source`, `displayName`)
+rather than the Agent Plugins `plugin.json` shape used elsewhere in this repo.
 
 ### Agent Plugins
 
@@ -90,6 +98,35 @@ If your client isn't listed below, you can generally still point it at:
 - Git URL: `https://github.com/stripe/ai`
 - Subdirectory: [`providers/agent-plugins/plugin/`](/providers/agent-plugins/plugin).
 
+The clients below are drawn from the Agent Plugins spec's own
+[compatible clients list](https://agent-plugins.org/compatible-clients)
+([source](https://github.com/agentplugins/agent-plugins-site/blob/main/lib/compatible-clients.ts)).
+
+A few of these clients look for a bare, root-level `marketplace.json` (or a
+`.claude-plugin/marketplace.json`/`.cursor-plugin/marketplace.json` fallback),
+but they don't all parse the same schema. For example:
+- Claude Code's format requires a top-level `owner` object and per-plugin
+  `description`/`version`/`author` fields — see the
+  [Claude Code marketplace docs](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces).
+- Codex checks four candidate paths (`.agents/plugins/marketplace.json`,
+  `.agents/plugins/api_marketplace.json`, `.claude-plugin/marketplace.json`,
+  and `.cursor-plugin/marketplace.json` — notably *not* `.codex-plugin/marketplace.json`)
+  and additionally expects a Codex-specific `policy.installation`/
+  `policy.authentication` object and optional `category` per plugin, per the
+  `RawMarketplaceManifest`/`RawMarketplaceManifestPlugin` types in
+  [`codex-rs/core-plugins/src/marketplace.rs`](https://github.com/openai/codex/blob/main/codex-rs/core-plugins/src/marketplace.rs).
+- GitHub Copilot CLI checks `.github/plugin/marketplace.json` first, then
+  falls back to `.claude-plugin/marketplace.json`, and documents itself as
+  compatible with the Claude Code schema plus optional "Open Plugin Spec"
+  extensions — see the
+  [Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference).
+
+In short: several clients converge on (or fall back to) the schema Claude
+Code originated, but Codex's variant adds required fields Claude's doesn't
+have, and Cursor and Kimi use their own dedicated formats — so a listing
+built for one client isn't guaranteed to validate on another without checking
+that client's own docs or source first.
+
 #### GitHub Copilot CLI
 
 Run these commands in your project:
@@ -98,6 +135,8 @@ Run these commands in your project:
 copilot plugin marketplace add stripe/ai
 copilot plugin install stripe@stripe
 ```
+
+Source: [Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference).
 
 #### VS Code
 
@@ -108,16 +147,22 @@ Add this repo as a plugin marketplace in your `settings.json`, then install
 "chat.plugins.marketplaces": ["stripe/ai"]
 ```
 
+Source: [VS Code Agent Plugins docs](https://code.visualstudio.com/docs/agent-customization/agent-plugins).
+
 #### OpenClaw
 
-OpenClaw resolves marketplaces from a repo's `.claude-plugin/marketplace.json`,
-which this repo already publishes for Claude Code. Run these commands in your
-project:
+OpenClaw resolves marketplaces from a repo's `.claude-plugin/marketplace.json`
+first, falling back to a bare root `marketplace.json` — this repo already
+publishes the former for Claude Code. Run these commands in your project:
 
 ```bash
 openclaw plugins marketplace list stripe/ai
 openclaw plugins install stripe --marketplace stripe/ai
 ```
+
+Sources: [OpenClaw plugin bundles docs](https://docs.openclaw.ai/plugins/bundles)
+and the `MARKETPLACE_MANIFEST_CANDIDATES` constant in
+[`src/plugins/marketplace.ts`](https://github.com/openclaw/openclaw/blob/main/src/plugins/marketplace.ts).
 
 #### Hermes Agent
 
@@ -133,6 +178,12 @@ hermes plugins list
 hermes plugins enable stripe
 ```
 
+Sources: [Hermes Agent plugin docs](https://hermes-agent.nousresearch.com/docs/developer-guide/plugins#portable-agent-plugins-v1-packages),
+and the subdirectory-shorthand parsing in
+[`hermes_cli/plugin_packs.py`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/plugin_packs.py)
+and the `--enable`/`--no-enable` prompt-skip flags in
+[`hermes_cli/subcommands/plugins.py`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/subcommands/plugins.py).
+
 #### NanoClaw
 
 NanoClaw only stamps templates from a local directory, so copy the package in
@@ -144,11 +195,15 @@ cp -r /tmp/stripe-ai/providers/agent-plugins/plugin templates/stripe
 ncl groups create --template stripe --name "Stripe Agent" --yes
 ```
 
+Source: [NanoClaw templates docs](https://github.com/nanocoai/nanoclaw/blob/main/docs/templates.md).
+
 #### Kiro
 
 Kiro already lists Stripe in its curated registry. Browse to
 [kiro.dev/powers](https://kiro.dev/powers), find Stripe, and select
 **Add to Kiro** — no manual installation is required.
+
+Source: [Kiro powers docs](https://kiro.dev/docs/powers/).
 
 
 ## Manual installation


### PR DESCRIPTION
Extends the plugin installation docs in `README.md` to cover additional
clients that support (or claim to support) the [Agent Plugins](https://agent-plugins.org/)
standard, plus adds two new manifest/listing files so those clients can pick
up this repo's package directly:

- `.github/plugin/marketplace.json` — a marketplace listing at the path
  GitHub Copilot CLI (and VS Code) check for, pointing at
  `providers/agent-plugins/plugin/`.
- `.kimi-plugin/plugin.json` — Kimi Code CLI's own plugin manifest format
  (distinct from the Agent Plugins `plugin.json` shape), pointing at the
  same skills and MCP server.

Claude Code, Cursor, Codex, and Grok already had working, dedicated
marketplace files before this change and are untouched here.

## Sources for each install command

So reviewers can verify these commands without installing every client:

- **Gemini CLI**: [extensions docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/index.md)
- **Kimi CLI**: [plugin docs](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins)
  ([mirror](https://github.com/MoonshotAI/kimi-code/blob/main/docs/en/customization/plugins.md)),
  [example marketplace.json](https://github.com/MoonshotAI/kimi-code/blob/main/plugins/marketplace.json)
- **GitHub Copilot CLI**: [CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)
- **VS Code**: [Agent Plugins docs](https://code.visualstudio.com/docs/agent-customization/agent-plugins)
- **OpenClaw**: [plugin bundles docs](https://docs.openclaw.ai/plugins/bundles),
  [`marketplace.json` candidate paths in source](https://github.com/openclaw/openclaw/blob/main/src/plugins/marketplace.ts)
- **Hermes Agent**: [plugin docs](https://hermes-agent.nousresearch.com/docs/developer-guide/plugins#portable-agent-plugins-v1-packages),
  [subdirectory shorthand in source](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/plugin_packs.py),
  [`--enable`/`--no-enable` flags in source](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/subcommands/plugins.py)
- **NanoClaw**: [templates docs](https://github.com/nanocoai/nanoclaw/blob/main/docs/templates.md)
- **Kiro**: [powers docs](https://kiro.dev/docs/powers/)
- Full list of clients considered: the Agent Plugins spec's own
  [compatible clients registry](https://agent-plugins.org/compatible-clients)
  ([source](https://github.com/agentplugins/agent-plugins-site/blob/main/lib/compatible-clients.ts))

## Do all "root marketplace.json" clients share one format?

No — several clients look for a marketplace listing at a root-ish path, but
the schemas diverge:

- **Claude Code** requires a top-level `owner` object and per-plugin
  `description`/`version`/`author` fields
  ([docs](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)).
- **Codex** checks four candidate paths (`.agents/plugins/marketplace.json`,
  `.agents/plugins/api_marketplace.json`, `.claude-plugin/marketplace.json`,
  `.cursor-plugin/marketplace.json` — notably *not* `.codex-plugin/marketplace.json`)
  and requires a Codex-specific `policy.installation`/`policy.authentication`
  object per plugin, per the `RawMarketplaceManifest` types in
  [`marketplace.rs`](https://github.com/openai/codex/blob/main/codex-rs/core-plugins/src/marketplace.rs).
- **GitHub Copilot CLI** checks `.github/plugin/marketplace.json` first, then
  falls back to `.claude-plugin/marketplace.json`, and documents itself as
  compatible with Claude's schema plus optional "Open Plugin Spec" extensions
  ([docs](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)).
- **OpenClaw** checks `.claude-plugin/marketplace.json` first, then falls
  back to a bare root `marketplace.json`
  ([source](https://github.com/openclaw/openclaw/blob/main/src/plugins/marketplace.ts)).
- **Cursor** and **Kimi** each use their own dedicated formats/paths with no
  shared fallback.

Net: several clients converge on (or fall back to) the schema Claude Code
originated, but Codex's variant adds required fields Claude's doesn't have,
so a listing built for one client isn't guaranteed to validate on another.
This is also called out inline in `README.md`.
