### PR TITLE
docs: fix agent skills index link

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -9,4 +9,4 @@ Stripe has:
 - MCP Prompts
 - Agent skills
 
-This folder is a collection of [agent skills](https://agentskills.io) to steer your agents to build optimal Stripe integrations. These are synced automatically from [docs.stripe.com/.well-known/skills](https://docs.stripe.com/.well-known/skills) via the [sync-skills workflow](/.github/workflows/sync-skills.yml).
+This folder is a collection of [agent skills](https://agentskills.io) to steer your agents to build optimal Stripe integrations. These are synced automatically from [docs.stripe.com/.well-known/skills/index.json](https://docs.stripe.com/.well-known/skills/index.json) via the [sync-skills workflow](/.github/workflows/sync-skills.yml).


### PR DESCRIPTION
## Summary

Fixes #479.

The Skills README linked to https://docs.stripe.com/.well-known/skills, which is a dead endpoint. Update it to Stripe's canonical machine-readable Skills index: https://docs.stripe.com/.well-known/skills/index.json.

## Reproduction and resolution

- Before this change, the Issue URL returned HTTP 404.
- After this change, the replacement URL returns HTTP 200 and serves the Skills index.
- The replacement is an index JSON endpoint by design; it is the discovery endpoint consumed by Skills tooling, rather than an HTML documentation page.

## Compatibility and risk

Documentation-only change. No runtime code, API behavior, dependencies, sync logic, or generated files are changed. There are no state, concurrency, atomicity, or migration concerns.

## Testing

- git diff --check — passed.
- Original endpoint — reproduced HTTP 404.
- Replacement endpoint — verified HTTP 200 with curl.

Build and unit tests were not run because this PR changes only one Markdown URL and has no executable code path. Automated link-checking could be added separately, but is outside the scope of this Issue.