### PR TITLE
fix(provider): throw NoContentGeneratedError when a response has no choices

### DIFF
--- a/llm/ai-sdk/provider/stripe-language-model-v3.ts
+++ b/llm/ai-sdk/provider/stripe-language-model-v3.ts
@@ -12,6 +12,7 @@ import type {
   LanguageModelV3StreamResult,
   LanguageModelV3Usage,
 } from '@ai-sdk/provider';
+import {NoContentGeneratedError} from '@ai-sdk/provider';
 import {
   ParseResult,
   createEventSourceResponseHandler,
@@ -320,6 +321,11 @@ export class StripeLanguageModelV3 implements LanguageModelV3 {
     }
 
     const choice = response.choices[0];
+    if (choice == null) {
+      throw new NoContentGeneratedError({
+        message: 'Response contained no choices',
+      });
+    }
 
     const content: LanguageModelV3Content[] = [];
 

--- a/llm/ai-sdk/provider/stripe-language-model.ts
+++ b/llm/ai-sdk/provider/stripe-language-model.ts
@@ -9,6 +9,7 @@ import {
   LanguageModelV2Content,
   LanguageModelV2FinishReason,
   LanguageModelV2StreamPart,
+  NoContentGeneratedError,
 } from '@ai-sdk/provider';
 import {
   ParseResult,
@@ -346,6 +347,11 @@ export class StripeLanguageModel implements LanguageModelV2 {
     }
 
     const choice = response.choices[0];
+    if (choice == null) {
+      throw new NoContentGeneratedError({
+        message: 'Response contained no choices',
+      });
+    }
 
     // Convert response to AI SDK V2 format
     const content: LanguageModelV2Content[] = [];

--- a/llm/ai-sdk/provider/tests/stripe-language-model-v3.test.ts
+++ b/llm/ai-sdk/provider/tests/stripe-language-model-v3.test.ts
@@ -5,6 +5,7 @@
 import {StripeLanguageModelV3} from '../stripe-language-model-v3';
 import {StripeProviderAccessError} from '../stripe-language-model';
 import type {LanguageModelV3CallOptions} from '@ai-sdk/provider';
+import {NoContentGeneratedError} from '@ai-sdk/provider';
 
 describe('StripeLanguageModelV3', () => {
   let model: StripeLanguageModelV3;
@@ -618,6 +619,34 @@ describe('StripeLanguageModelV3', () => {
             error.statusCode !== undefined
         ).toBe(true);
       }
+    });
+  });
+
+  describe('doGenerate with empty choices', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should throw NoContentGeneratedError when a 200 response has no choices', async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            choices: [],
+            usage: {prompt_tokens: 5, completion_tokens: 0, total_tokens: 5},
+          }),
+          {status: 200, headers: {'Content-Type': 'application/json'}}
+        )
+      ) as unknown as typeof fetch;
+
+      const options: LanguageModelV3CallOptions = {
+        prompt: [{role: 'user', content: [{type: 'text', text: 'Hello'}]}],
+      };
+
+      await expect(model.doGenerate(options)).rejects.toBeInstanceOf(
+        NoContentGeneratedError
+      );
     });
   });
 });

--- a/llm/ai-sdk/provider/tests/stripe-language-model.test.ts
+++ b/llm/ai-sdk/provider/tests/stripe-language-model.test.ts
@@ -4,6 +4,7 @@
 
 import {StripeLanguageModel, StripeProviderAccessError} from '../stripe-language-model';
 import type {LanguageModelV2CallOptions} from '@ai-sdk/provider';
+import {NoContentGeneratedError} from '@ai-sdk/provider';
 
 describe('StripeLanguageModel', () => {
   let model: StripeLanguageModel;
@@ -628,5 +629,32 @@ describe('StripeLanguageModel', () => {
       }
     });
   });
-});
 
+  describe('doGenerate with empty choices', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should throw NoContentGeneratedError when a 200 response has no choices', async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            choices: [],
+            usage: {prompt_tokens: 5, completion_tokens: 0, total_tokens: 5},
+          }),
+          {status: 200, headers: {'Content-Type': 'application/json'}}
+        )
+      ) as unknown as typeof fetch;
+
+      const options: LanguageModelV2CallOptions = {
+        prompt: [{role: 'user', content: [{type: 'text', text: 'Hello'}]}],
+      };
+
+      await expect(model.doGenerate(options)).rejects.toBeInstanceOf(
+        NoContentGeneratedError
+      );
+    });
+  });
+});


### PR DESCRIPTION
`openAIResponseSchema` allows an empty `choices` array, so an HTTP 200 response of `{"choices": [], "usage": {...}}` crashes `doGenerate` with an unhandled `TypeError` at `response.choices[0].message` in both `StripeLanguageModel` (V2) and `StripeLanguageModelV3`. The dereference sits outside the try/catch, which only wraps `postJsonToApi`, so callers get a raw `TypeError` instead of a typed SDK error.

This adds an explicit guard after `response.choices[0]` in both models that throws `NoContentGeneratedError` from `@ai-sdk/provider`, the SDK's standard error for a response with no generated content, with a clear message.

Tests: one regression test per model asserting a 200 response with empty choices rejects with `NoContentGeneratedError`. Both fail with `TypeError` before the fix and pass after. Full suite: 331 passing.
