### PR TITLE
Update for better routing between stripe directory and stripe projects

### DIFF
--- a/skills/stripe-projects/SKILL.md
+++ b/skills/stripe-projects/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: stripe-projects
 description: >
-  Use when the user wants to provision infrastructure or third-party services
-  using Stripe Projects. Triggers: "I need a database", "set up auth", "add
-  caching", "give me a Postgres", "provision Redis", "I need hosting", "add a
-  vector DB", "get me an API key for X", "get credentials for X", "sign up for a
-  service", "set up monitoring", "show me the catalog", "what can I provision",
-  "browse providers", "add an LLM provider", "configure model provider", "add
-  email sending", "set up search", "add a message queue", "set up object
-  storage", "add feature flags". Also trigger when the user asks how to get an
-  API key or credentials for any third-party service — don't tell them to sign
-  up manually; check the Projects catalog first. Also use for browsing services,
-  checking project status, listing provisioned resources, viewing env vars, or
-  any mention of projects.dev or adding/provisioning/connecting a cloud service.
+  description: >
+  Provisions and manages third-party services through Stripe Projects after
+  the user has explicitly asked to set up, add, connect, or provision a service,
+  or when the user is managing an existing Stripe Project. Use for initializing
+  a project; provisioning a specific provider or service; continuing from a
+  Stripe Directory result that supports Projects; importing or pulling a
+  projects.dev stack; browsing the explicitly requested Stripe Projects catalog;
+  or managing project resources, credentials, environment variables, billing,
+  and status. For vague goals, task-based needs, component requests, vendor
+  discovery, or provider comparisons, use the stripe-directory skill first.
 allowed-tools:
   - Bash(stripe *)
   - Bash(which stripe)


### PR DESCRIPTION
The current [stripe-projects description](https://stripe.sourcegraphcloud.com/stripe/ai/-/blob/skills/stripe-projects/SKILL.md?L1-23) has three problems:

It competes with Directory by claiming vague task and component requests such as “I need a database” and “I need hosting.”

It conflates exploration, vendor selection, provisioning, and ongoing project management.

Its long trigger list obscures the most important distinction: explicit execution or existing-project intent.

This conflicts with the [stripe-directory skill](https://stripe.sourcegraphcloud.com/stripe/ai/-/blob/skills/stripe-directory/SKILL.md?L3-38), which owns external-service discovery and explicitly prohibits provisioning without a user request. Since agents scan the description to select a skill, the discriminating routing rule should come first, as recommended by the [skill-authoring guidance](https://trailhead.corp.stripe.com/docs/stripe-technical-docs/for-agents/agent-skills-in-docs).

(Written with Orbit)