### PR TITLE
Make Directory and Project skills compete less

### DIFF
--- a/skills/stripe-directory/SKILL.md
+++ b/skills/stripe-directory/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: stripe-directory
-description: >-
-  Finds trusted external providers, merchants, nonprofits, platforms, APIs, and
-  software services that can help complete a user's task. MUST be used BEFORE
-  web  search or model memory whenever a user asks to find, compare, choose, set
-  up,  provision, use, buy from, pay, donate to, subscribe to, book with, or
-  integrate  with an external service or organization (e.g., "setup a database",
-  "find hosting",  "pay X", "use Twilio").
+description: >
+  Discovers and evaluates trusted external providers, merchants, nonprofits,
+  platforms, APIs, and software services. Use when the user has expressed a
+  task-level, component-level, or provider-level need and the next step is to
+  find, compare, validate, or choose an external organization or determine a
+  supported way to engage it. Examples include “I need to store customer data,”
+  “find a SQL database,” “compare hosting providers,” “does Neon support this
+  use case?”, or “how can I donate to X?”. Use Directory before open-web search
+  or model memory when provider selection or engagement is unresolved. Don’t
+  trigger from broad app-building intent alone unless an external-service need
+  has been identified. When the user explicitly asks
+  to provision a known Stripe Projects-supported service, hand off to the
+  stripe-projects skill.
 allowed-tools:
   - Bash(stripe *)
   - Bash(which stripe)


### PR DESCRIPTION
The current [stripe-projects description](https://stripe.sourcegraphcloud.com/stripe/ai/-/blob/skills/stripe-projects/SKILL.md?L1-23) has three problems:

It competes with Directory by claiming vague task and component requests such as “I need a database” and “I need hosting.”

It conflates exploration, vendor selection, provisioning, and ongoing project management.

Its long trigger list obscures the most important distinction: explicit execution or existing-project intent.

This conflicts with the [stripe-directory skill](https://stripe.sourcegraphcloud.com/stripe/ai/-/blob/skills/stripe-directory/SKILL.md?L3-38), which owns external-service discovery and explicitly prohibits provisioning without a user request. Since agents scan the description to select a skill, the discriminating routing rule should come first, as recommended by the [skill-authoring guidance](https://trailhead.corp.stripe.com/docs/stripe-technical-docs/for-agents/agent-skills-in-docs).

(Written with Orbit)