### PR TITLE
fix(token-meter): stop consuming abandoned streams

### DIFF
--- a/llm/token-meter/tests/token-meter-anthropic.test.ts
+++ b/llm/token-meter/tests/token-meter-anthropic.test.ts
@@ -3,6 +3,7 @@
  */
 
 import Stripe from 'stripe';
+import {Stream as AnthropicStream} from '@anthropic-ai/sdk/streaming';
 import {createTokenMeter} from '../token-meter';
 import type {MeterConfig} from '../types';
 
@@ -231,6 +232,71 @@ describe('TokenMeter - Anthropic Provider', () => {
   });
 
   describe('Messages - Streaming', () => {
+    it('does not consume the source before the returned stream is read', async () => {
+      const meter = createTokenMeter(TEST_API_KEY, config);
+      let pulls = 0;
+
+      async function* chunks() {
+        pulls += 1;
+        yield {
+          type: 'message_start',
+          message: {
+            id: 'msg_lazy',
+            model: 'claude-3-5-sonnet-20241022',
+            usage: {input_tokens: 10, output_tokens: 0},
+          },
+        };
+      }
+
+      const source = new AnthropicStream(chunks, new AbortController());
+      const wrapped = meter.trackUsageStreamAnthropic(source as any, 'cus_123');
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(pulls).toBe(0);
+      expect(wrapped).toBeInstanceOf(AnthropicStream);
+    });
+
+    it('closes the source when the returned stream is abandoned', async () => {
+      const meter = createTokenMeter(TEST_API_KEY, config);
+      let finalized = false;
+      let release!: () => void;
+      const blocked = new Promise<void>(resolve => {
+        release = resolve;
+      });
+
+      async function* chunks() {
+        try {
+          yield {
+            type: 'message_start',
+            message: {
+              id: 'msg_cancel',
+              model: 'claude-3-5-sonnet-20241022',
+              usage: {input_tokens: 10, output_tokens: 0},
+            },
+          };
+          await blocked;
+          yield {type: 'message_stop'};
+        } finally {
+          finalized = true;
+        }
+      }
+
+      const source = new AnthropicStream(chunks, new AbortController());
+      const wrapped = meter.trackUsageStreamAnthropic(source as any, 'cus_123');
+
+      try {
+        for await (const _chunk of wrapped) {
+          break;
+        }
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(finalized).toBe(true);
+      } finally {
+        release();
+      }
+    });
+
     it('should track usage from basic streaming message', async () => {
       const meter = createTokenMeter(TEST_API_KEY, config);
 

--- a/llm/token-meter/tests/token-meter-openai.test.ts
+++ b/llm/token-meter/tests/token-meter-openai.test.ts
@@ -3,6 +3,7 @@
  */
 
 import Stripe from 'stripe';
+import {Stream as OpenAIStream} from 'openai/streaming';
 import {createTokenMeter} from '../token-meter';
 import type {MeterConfig} from '../types';
 
@@ -227,6 +228,99 @@ describe('TokenMeter - OpenAI Provider', () => {
   });
 
   describe('Chat Completions - Streaming', () => {
+    it('does not consume the source before the returned stream is read', async () => {
+      const meter = createTokenMeter(TEST_API_KEY, config);
+      let pulls = 0;
+
+      async function* chunks() {
+        pulls += 1;
+        yield {
+          id: 'chatcmpl-lazy',
+          object: 'chat.completion.chunk',
+          created: Date.now(),
+          model: 'gpt-4o-mini',
+          choices: [],
+        };
+      }
+
+      const source = new OpenAIStream(chunks, new AbortController());
+      const wrapped = meter.trackUsageStreamOpenAI(source as any, 'cus_123');
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(pulls).toBe(0);
+      expect(wrapped).toBeInstanceOf(OpenAIStream);
+    });
+
+    it('closes the source when the returned stream is abandoned', async () => {
+      const meter = createTokenMeter(TEST_API_KEY, config);
+      let finalized = false;
+      let release!: () => void;
+      const blocked = new Promise<void>(resolve => {
+        release = resolve;
+      });
+
+      async function* chunks() {
+        try {
+          yield {
+            id: 'chatcmpl-cancel',
+            object: 'chat.completion.chunk',
+            created: Date.now(),
+            model: 'gpt-4o-mini',
+            choices: [],
+          };
+          await blocked;
+          yield {
+            id: 'chatcmpl-unused',
+            object: 'chat.completion.chunk',
+            created: Date.now(),
+            model: 'gpt-4o-mini',
+            choices: [],
+          };
+        } finally {
+          finalized = true;
+        }
+      }
+
+      const source = new OpenAIStream(chunks, new AbortController());
+      const wrapped = meter.trackUsageStreamOpenAI(source as any, 'cus_123');
+
+      try {
+        for await (const _chunk of wrapped) {
+          break;
+        }
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(finalized).toBe(true);
+      } finally {
+        release();
+      }
+    });
+
+    it('propagates a source error once and finalizes the source', async () => {
+      const meter = createTokenMeter(TEST_API_KEY, config);
+      const sourceError = new Error('source failed before the first chunk');
+      let finalized = false;
+
+      async function* chunks(): AsyncGenerator<any> {
+        try {
+          throw sourceError;
+        } finally {
+          finalized = true;
+        }
+      }
+
+      const source = new OpenAIStream(chunks, new AbortController());
+      const wrapped = meter.trackUsageStreamOpenAI(source as any, 'cus_123');
+      const iterator = wrapped[Symbol.asyncIterator]();
+
+      await expect(iterator.next()).rejects.toBe(sourceError);
+      await expect(iterator.next()).resolves.toEqual({done: true, value: undefined});
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(finalized).toBe(true);
+    });
+
     it('should track usage from basic streaming chat', async () => {
       const meter = createTokenMeter(TEST_API_KEY, config);
 

--- a/llm/token-meter/token-meter.ts
+++ b/llm/token-meter/token-meter.ts
@@ -4,7 +4,7 @@
 
 import Stripe from 'stripe';
 import type OpenAI from 'openai';
-import type {Stream} from 'openai/streaming';
+import type {Stream as OpenAIStream} from 'openai/streaming';
 import type Anthropic from '@anthropic-ai/sdk';
 import type {Stream as AnthropicStream} from '@anthropic-ai/sdk/streaming';
 import type {
@@ -16,11 +16,29 @@ import {logUsageEvent} from './meter-event-logging';
 import {
   detectResponse,
   isGeminiStream,
-  extractUsageFromChatStream,
-  extractUsageFromResponseStream,
-  extractUsageFromAnthropicStream,
   type DetectedResponse,
 } from './utils/type-detection';
+
+function wrapSdkStream<T extends AsyncIterable<unknown> & {controller: AbortController}>(
+  source: T,
+  iterator: () => AsyncIterator<unknown>
+): T {
+  const StreamConstructor = source.constructor as new (
+    iterator: () => AsyncIterator<unknown>,
+    controller: AbortController
+  ) => T;
+
+  // The SDK streams are class instances. Keeping this fallback makes the
+  // structural test doubles accepted by the existing public type usable too.
+  if ((StreamConstructor as unknown) === Object) {
+    return {
+      controller: source.controller,
+      [Symbol.asyncIterator]: iterator,
+    } as T;
+  }
+
+  return new StreamConstructor(iterator, source.controller);
+}
 
 /**
  * Supported response types from all AI providers
@@ -36,8 +54,8 @@ export type SupportedResponse =
  * Supported stream types from all AI providers
  */
 export type SupportedStream =
-  | Stream<OpenAI.ChatCompletionChunk>
-  | Stream<OpenAI.Responses.ResponseStreamEvent>
+  | OpenAIStream<OpenAI.ChatCompletionChunk>
+  | OpenAIStream<OpenAI.Responses.ResponseStreamEvent>
   | AnthropicStream<Anthropic.Messages.RawMessageStreamEvent>
   | GenerateContentStreamResult;
 
@@ -58,8 +76,8 @@ export interface TokenMeter {
    */
   trackUsageStreamOpenAI<
     T extends
-      | Stream<OpenAI.ChatCompletionChunk>
-      | Stream<OpenAI.Responses.ResponseStreamEvent>
+      | OpenAIStream<OpenAI.ChatCompletionChunk>
+      | OpenAIStream<OpenAI.Responses.ResponseStreamEvent>
   >(
     stream: T,
     stripeCustomerId: string
@@ -172,78 +190,126 @@ export function createTokenMeter(
 
     trackUsageStreamOpenAI<
       T extends
-        | Stream<OpenAI.ChatCompletionChunk>
-        | Stream<OpenAI.Responses.ResponseStreamEvent>
+        | OpenAIStream<OpenAI.ChatCompletionChunk>
+        | OpenAIStream<OpenAI.Responses.ResponseStreamEvent>
     >(stream: T, stripeCustomerId: string): T {
-      const [peekStream, stream2] = stream.tee();
+      const meteredStream = wrapSdkStream(
+        stream,
+        async function* () {
+          let streamType: 'chat_completion' | 'response_api' | null = null;
+          let model = '';
+          let inputTokens = 0;
+          let outputTokens = 0;
 
-      (async () => {
-        // Peek at the first chunk to determine stream type
-        const [stream1, meterStream] = peekStream.tee();
-        const reader = stream1[Symbol.asyncIterator]();
-        const firstChunk = await reader.next();
-        
-        let detected: DetectedResponse | null = null;
-        
-        if (!firstChunk.done && firstChunk.value) {
-          const chunk = firstChunk.value as any;
-          
-          // Check if it's an OpenAI Chat stream (has choices array)
-          if ('choices' in chunk && Array.isArray(chunk.choices)) {
-            detected = await extractUsageFromChatStream(meterStream as any);
+          for await (const value of stream) {
+            const chunk = value as any;
+
+            if (!streamType) {
+              if ('choices' in chunk && Array.isArray(chunk.choices)) {
+                streamType = 'chat_completion';
+              } else if (
+                chunk.type &&
+                typeof chunk.type === 'string' &&
+                chunk.type.startsWith('response.')
+              ) {
+                streamType = 'response_api';
+              }
+            }
+
+            if (streamType === 'chat_completion') {
+              model = chunk.model || model;
+              if (chunk.usage) {
+                inputTokens = chunk.usage.prompt_tokens ?? 0;
+                outputTokens = chunk.usage.completion_tokens ?? 0;
+              }
+            } else if (streamType === 'response_api' && chunk.response) {
+              model = chunk.response.model || model;
+              if (chunk.response.usage) {
+                inputTokens = chunk.response.usage.input_tokens ?? 0;
+                outputTokens = chunk.response.usage.output_tokens ?? 0;
+              }
+            }
+
+            yield value;
           }
-          // Check if it's an OpenAI Response API stream (has type starting with 'response.')
-          else if (chunk.type && typeof chunk.type === 'string' && chunk.type.startsWith('response.')) {
-            detected = await extractUsageFromResponseStream(meterStream as any);
-          }
-          else {
-            console.warn('Unable to detect OpenAI stream type from first chunk:', chunk);
+
+          const detected: DetectedResponse | null =
+            streamType && model
+              ? {
+                  provider: 'openai',
+                  type: streamType,
+                  model,
+                  inputTokens,
+                  outputTokens,
+                }
+              : null;
+
+          if (detected) {
+            logUsageEvent(stripeClient, config, {
+              model: detected.model,
+              provider: detected.provider,
+              usage: {
+                inputTokens: detected.inputTokens,
+                outputTokens: detected.outputTokens,
+              },
+              stripeCustomerId,
+            });
+          } else {
+            console.warn('Unable to extract usage from OpenAI stream');
           }
         }
+      );
 
-        if (detected) {
-          logUsageEvent(stripeClient, config, {
-            model: detected.model,
-            provider: detected.provider,
-            usage: {
-              inputTokens: detected.inputTokens,
-              outputTokens: detected.outputTokens,
-            },
-            stripeCustomerId,
-          });
-        } else {
-          console.warn('Unable to extract usage from OpenAI stream');
-        }
-      })();
-
-      return stream2 as T;
+      return meteredStream as T;
     },
 
     trackUsageStreamAnthropic(
       stream: AnthropicStream<Anthropic.Messages.RawMessageStreamEvent>,
       stripeCustomerId: string
     ): AnthropicStream<Anthropic.Messages.RawMessageStreamEvent> {
-      const [peekStream, stream2] = stream.tee();
+      return wrapSdkStream(
+        stream,
+        async function* () {
+          let model = '';
+          let inputTokens = 0;
+          let outputTokens = 0;
 
-      (async () => {
-        const detected = await extractUsageFromAnthropicStream(peekStream);
+          for await (const chunk of stream) {
+            if (chunk.type === 'message_start') {
+              model = chunk.message.model;
+              inputTokens = chunk.message.usage.input_tokens ?? 0;
+            } else if (chunk.type === 'message_delta') {
+              outputTokens = chunk.usage.output_tokens ?? 0;
+            }
 
-        if (detected) {
-          logUsageEvent(stripeClient, config, {
-            model: detected.model,
-            provider: detected.provider,
-            usage: {
-              inputTokens: detected.inputTokens,
-              outputTokens: detected.outputTokens,
-            },
-            stripeCustomerId,
-          });
-        } else {
-          console.warn('Unable to extract usage from Anthropic stream');
+            yield chunk;
+          }
+
+          const detected: DetectedResponse | null = model
+            ? {
+                provider: 'anthropic',
+                type: 'chat_completion',
+                model,
+                inputTokens,
+                outputTokens,
+              }
+            : null;
+
+          if (detected) {
+            logUsageEvent(stripeClient, config, {
+              model: detected.model,
+              provider: detected.provider,
+              usage: {
+                inputTokens: detected.inputTokens,
+                outputTokens: detected.outputTokens,
+              },
+              stripeCustomerId,
+            });
+          } else {
+            console.warn('Unable to extract usage from Anthropic stream');
+          }
         }
-      })();
-
-      return stream2;
+      ) as AnthropicStream<Anthropic.Messages.RawMessageStreamEvent>;
     },
   };
 }


### PR DESCRIPTION
## Summary

The OpenAI and Anthropic streaming meters currently split the SDK stream and drain a metering branch in an unawaited background task. The SDK `tee()` iterators do not propagate `return()`, so breaking out of the returned stream does not close the source request. The second OpenAI split also retains results for a peek branch that stops after its first chunk.

This change meters each provider inline through a single SDK `Stream` wrapper. Usage is accumulated as chunks pass to the caller and logged after normal completion. Early termination now closes the source iterator, while the returned value keeps the provider stream class and its stream methods. Provider SDKs remain optional runtime dependencies.

Early-cancelled streams are no longer drained solely to obtain final usage metadata. If the consumer stops before that metadata arrives, the source is closed and no complete usage event is emitted from unavailable final metadata.

## Testing

- Added real OpenAI and Anthropic stream tests covering lazy consumption and provider stream-class preservation.
- Added controlled-generator coverage for early consumer termination, source finalization, and one-time error propagation.
- Ran the full token-meter test suite and TypeScript build checks.
