### PR TITLE
fix(token-meter): use cumulative Anthropic input usage

### DIFF
--- a/llm/token-meter/tests/token-meter-anthropic.test.ts
+++ b/llm/token-meter/tests/token-meter-anthropic.test.ts
@@ -3,6 +3,7 @@
  */
 
 import Stripe from 'stripe';
+import Anthropic from '@anthropic-ai/sdk';
 import {createTokenMeter} from '../token-meter';
 import type {MeterConfig} from '../types';
 
@@ -457,6 +458,112 @@ describe('TokenMeter - Anthropic Provider', () => {
           }),
         })
       );
+    });
+  });
+
+  describe('Messages - Streaming cumulative usage', () => {
+    it.each([
+      {
+        name: 'replace the initial input count with the final cumulative count',
+        updates: [{input_tokens: 10682, output_tokens: 510}],
+        inputTokens: 10682,
+      },
+      {
+        name: 'use the last cumulative count without adding earlier counts',
+        updates: [
+          {input_tokens: 5000, output_tokens: 100},
+          {input_tokens: 10682, output_tokens: 510},
+        ],
+        inputTokens: 10682,
+      },
+      {
+        name: 'retain the initial input count when the delta omits it',
+        updates: [{output_tokens: 510}],
+        inputTokens: 25,
+      },
+      {
+        name: 'retain the initial input count when the delta supplies null',
+        updates: [{input_tokens: null, output_tokens: 510}],
+        inputTokens: 25,
+      },
+      {
+        name: 'retain an updated input count when a later delta omits it',
+        updates: [
+          {input_tokens: 10682, output_tokens: 100},
+          {output_tokens: 510},
+        ],
+        inputTokens: 10682,
+      },
+      {
+        name: 'retain an updated input count when a later delta supplies null',
+        updates: [
+          {input_tokens: 10682, output_tokens: 100},
+          {input_tokens: null, output_tokens: 510},
+        ],
+        inputTokens: 10682,
+      },
+      {
+        name: 'accept an explicit zero input count',
+        updates: [{input_tokens: 0, output_tokens: 510}],
+        inputTokens: 0,
+      },
+    ])('should $name', async ({updates, inputTokens}) => {
+      const events = [
+        {
+          type: 'message_start',
+          message: {
+            id: 'msg_cumulative',
+            type: 'message',
+            role: 'assistant',
+            content: [],
+            model: 'claude-3-5-sonnet-20241022',
+            stop_reason: null,
+            stop_sequence: null,
+            usage: {input_tokens: 25, output_tokens: 1},
+          },
+        },
+        ...updates.map(usage => ({
+          type: 'message_delta',
+          delta: {stop_reason: 'end_turn', stop_sequence: null},
+          usage,
+        })),
+        {type: 'message_stop'},
+      ];
+      const client = new Anthropic({
+        apiKey: 'test_anthropic_key',
+        fetch: async () => new Response(
+          events.map(event =>
+            `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`
+          ).join(''),
+          {headers: {'Content-Type': 'text/event-stream'}}
+        ),
+      });
+      const stream = await client.messages.create({
+        model: 'claude-3-5-sonnet-20241022',
+        max_tokens: 1024,
+        messages: [{role: 'user', content: 'Hello'}],
+        stream: true,
+      });
+      const meter = createTokenMeter(TEST_API_KEY, config);
+      const received = [];
+
+      for await (const event of meter.trackUsageStreamAnthropic(stream, 'cus_123')) {
+        received.push(event);
+      }
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(received).toEqual(events);
+      const payload = {
+        stripe_customer_id: 'cus_123',
+        model: 'anthropic/claude-3.5-sonnet',
+      };
+      expect(mockMeterEventsCreate.mock.calls.map(([event]) => event.payload))
+        .toEqual([
+          ...(inputTokens > 0
+            ? [{...payload, value: inputTokens.toString(), token_type: 'input'}]
+            : []),
+          {...payload, value: '510', token_type: 'output'},
+        ]);
     });
   });
 

--- a/llm/token-meter/utils/type-detection.ts
+++ b/llm/token-meter/utils/type-detection.ts
@@ -312,8 +312,9 @@ export async function extractUsageFromAnthropicStream(
         usage.input_tokens = chunk.message.usage.input_tokens ?? 0;
         model = chunk.message.model;
       }
-      // Capture usage from message_delta event (output tokens)
+      // Apply cumulative counts, keeping prior input usage when it is omitted.
       if (chunk.type === 'message_delta' && 'usage' in chunk) {
+        usage.input_tokens = chunk.usage.input_tokens ?? usage.input_tokens;
         usage.output_tokens = chunk.usage.output_tokens ?? 0;
       }
     }


### PR DESCRIPTION
Anthropic can revise `input_tokens` in `message_delta`, including after server-side tool use. The token meter only reads the count from `message_start`, so it can send a lower input count to Stripe. In the regression stream, the count starts at 25 and ends at 10,682; the existing code sends 25.

Use the latest non-null cumulative count, retaining the previous count when a delta omits it or supplies null. Explicit zero remains valid. This follows [Anthropic's streaming usage contract](https://platform.claude.com/docs/en/build-with-claude/streaming).

Seven regressions use the real Anthropic SDK's SSE parser with an offline response and mock only the Stripe billing client. They check revised counts, multiple cumulative updates, omitted/null values, zero, unchanged stream events, and the exact billing payloads. Five fail before the fix.

Validation from `llm/token-meter`: `pnpm exec jest --runInBand` (155 passed), `pnpm run build` (passed). No live inference or billing calls.

Related: #509 replaces this helper's caller with an inline accumulator. If that lands first, the same usage update needs to be carried into it.

## Post-Deploy Monitoring & Validation

On the first integration check after release, compare the emitted input event with the last non-null `message_delta.usage.input_tokens`, falling back to the start count when absent. A mismatch or duplicate usage event is a reason to hold rollout. Maintainers own release and rollout; this PR does not deploy anything.
